### PR TITLE
Handle os exec cases

### DIFF
--- a/initializer/components.py
+++ b/initializer/components.py
@@ -159,4 +159,6 @@ def handle_instrumenation_of_sub_processes():
     # - The environment override writer is removed
     # - Webhook integration is implemented
     # - A custom distro creation mechanism is developed
-    os.environ["PYTHONPATH"] = f"{os.environ['PYTHONPATH']}:/var/odigos/python/opentelemetry/instrumentation/auto_instrumentation"
+    auto_instrumentation_path = "/var/odigos/python/opentelemetry/instrumentation/auto_instrumentation"
+    if auto_instrumentation_path not in os.environ["PYTHONPATH"]:
+        os.environ["PYTHONPATH"] = f"{os.environ['PYTHONPATH']}:{auto_instrumentation_path}"

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -153,6 +153,7 @@ def handle_instrumenation_of_sub_processes():
     # to prevent application logic disruption.
     # 
     # Given OpenTelemetry's path removal during Distro creation, we must manually restore the path.
+    # This addresses cases where applications using os.exec* are not properly instrumented.
     # 
     # Note: This is a temporary solution and should be refactored when:
     # - The environment override writer is removed

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -26,14 +26,14 @@ from opamp.http_client import OpAMPHTTPClient, MockOpAMPClient
 MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 8)
 
 def initialize_components(trace_exporters = None, metric_exporters = None, log_exporters = None , span_processor = None):
-    
     # In case of forking, the OpAMP client should be started in the child process.
     # e.g when using gunicorn/celery with multiple workers.
     os.register_at_fork(
     after_in_child=lambda: start_opamp_client(threading.Event()),
     )  # pylint: disable=protected-access
     
-    
+    handle_instrumenation_of_sub_processes()
+
     resource_attributes_event = threading.Event()
     client = None
     
@@ -119,7 +119,6 @@ def initialize_logging_if_enabled(log_exporters, resource):
 
 
 def start_opamp_client(event):
-    
     if os.getenv('DISABLE_OPAMP_CLIENT', 'false').strip().lower() == 'true':
         return MockOpAMPClient(event)
         
@@ -141,3 +140,22 @@ def start_opamp_client(event):
 
 def is_supported_python_version():
     return sys.version_info >= MINIMUM_PYTHON_SUPPORTED_VERSION
+
+def handle_instrumenation_of_sub_processes():
+    # Resolves a path management issue introduced by OpenTelemetry's sitecustomize implementation.
+    # OpenTelemetry removed auto_instrumentation from the path to address a specific bug 
+    # (ref: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1050).
+    # This modification does not impact our use case, as we utilize auto_instrumentation as a package 
+    # and do not rely on opentelemetry-instrument for running instrumentations.
+    # 
+    # We are reintroducing the path to enable parallel execution with other agent that inject themselves via sitecustomize.
+    # We've observed that agents attempt to import user-defined sitecustomize.py [OpenTelemetry one in this case] prior to their own execution 
+    # to prevent application logic disruption.
+    # 
+    # Given OpenTelemetry's path removal during Distro creation, we must manually restore the path.
+    # 
+    # Note: This is a temporary solution and should be refactored when:
+    # - The environment override writer is removed
+    # - Webhook integration is implemented
+    # - A custom distro creation mechanism is developed
+    os.environ["PYTHONPATH"] = f"{os.environ['PYTHONPATH']}:/var/odigos/python/opentelemetry/instrumentation/auto_instrumentation"


### PR DESCRIPTION
This PR addresses an issue when running alongside New Relic.

New Relic operates by using the newrelic-admin run-program <user command> approach. As part of its process, it includes a bootstrap script implemented as a sitecustomize.py file. In their logic, they import other sitecustomize.py files found in sys.path to ensure they don't overwrite legitimate user-defined sitecustomize files—such as ours.

However, in OpenTelemetry's sitecustomize, there is a mechanism that removes the sitecustomize directory from the PYTHONPATH to address a bug related to the opentelemetry-instrument command (which we don't use).

This behavior causes an issue where the run-program logic, which eventually invokes os.execl with <user command>, cannot find our sitecustomize in the PYTHONPATH.