### PR TITLE
fix: downgraded importlib_metadata

### DIFF
--- a/initializer/lib_handling.py
+++ b/initializer/lib_handling.py
@@ -3,6 +3,7 @@ import importlib
 import os
 
 def reorder_python_path():
+    # Moves '/var/odigos/' paths to end of sys.path to prioritize user dependencies over odigos ones
     paths_to_move = [path for path in sys.path if path.startswith('/var/odigos/')]
     
     for path in paths_to_move:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   odigos-requests
     #   requests
@@ -14,7 +14,7 @@ charset-normalizer==3.4.1
     # via
     #   odigos-requests
     #   requests
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
@@ -25,8 +25,10 @@ idna==3.10
     # via
     #   odigos-requests
     #   requests
-importlib-metadata==8.5.0
-    # via opentelemetry-api
+importlib-metadata==6.0.0
+    # via
+    #   odigos-opentelemetry-python (setup.py)
+    #   opentelemetry-api
 odigos-requests==2.32.3.dev0
     # via odigos-opentelemetry-python (setup.py)
 opentelemetry-api==1.28.2
@@ -321,6 +323,7 @@ packaging==24.2
 protobuf==5.29.2
     # via
     #   googleapis-common-protos
+    #   odigos-opentelemetry-python (setup.py)
     #   opentelemetry-proto
 requests==2.32.3
     # via
@@ -340,7 +343,7 @@ urllib3-odigos==2.2.2
     #   odigos-requests
 uuid7==0.1.0
     # via odigos-opentelemetry-python (setup.py)
-wrapt==1.17.0
+wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "requests == 2.32.3",
         'opentelemetry-distro==0.49b2',
         'protobuf==5.29.2',
+        'importlib-metadata==6.0',
         'opentelemetry-exporter-otlp-proto-http==1.28.2',
         'opentelemetry-instrumentation==0.49b2',
         'opentelemetry-instrumentation-aio-pika==0.49b2',


### PR DESCRIPTION
In `importlib_metadata` version **8.5.0**, [_adapters is imported within the `metadata()` function](https://github.com/python/importlib_metadata/blob/v8.5.0/importlib_metadata/__init__.py#L488C9-L488C25), whereas in version **6.0**, [it is imported at the top of the file.](https://github.com/python/importlib_metadata/blob/v6.0.0/importlib_metadata/__init__.py#L421) Due to the enhancements we are making to `sys.path`, some parts of `importlib_metadata` are being loaded from the user's module, leading to a circular import issue.