### PR TITLE
fix: import exporter in main componenets.py file

### DIFF
--- a/initializer/components.py
+++ b/initializer/components.py
@@ -7,6 +7,9 @@ import atexit
 import sys
 import os
 
+from opentelemetry.exporter.otlp.proto.common._internal.trace_encoder import (
+            _encode_resource_spans,
+        )
 import opentelemetry.sdk._configuration as sdk_config
 from .process_resource import OdigosProcessResourceDetector
 from opentelemetry.sdk.resources import Resource

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.48",
+    version="1.0.49",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="Tamir David",
     author_email="tamir@odigos.io",


### PR DESCRIPTION
When a user application imports OpenTelemetry-related modules—such as the SDK or exporters—there can be conflicts with our own instrumentation (e.g., as seen with ChromaDB). Injecting our agent in such cases may lead to module resolution issues. In a related scenario, we've observed that modifying the sys.path before the exporter is imported (in another repository) causes the module to be loaded from the user's environment instead of our controlled dependencies. By importing the exporter before sys.path is altered, we ensure that our version is loaded into sys.modules, effectively taking precedence and avoiding such conflicts.