### PR TITLE
CORE-102 chore: reorder before importing distro

### DIFF
--- a/initializer/distro/__init__.py
+++ b/initializer/distro/__init__.py
@@ -1,0 +1,4 @@
+# To ensure user dependencies take precedence over those of the Odigos agent, we need to reorder the Python path accordingly.
+# This is crucial because users might rely on different versions of libraries that overlap with those used by the agent. By prioritizing their dependencies, we reduce the risk of introducing compatibility issues or breaking changes in the user's application.
+from ..lib_handling import reorder_python_path
+reorder_python_path()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.51",
+    version="1.0.52",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="Tamir David",
     author_email="tamir@odigos.io",


### PR DESCRIPTION
To ensure user dependencies take precedence over those of the Odigos agent, we need to reorder the Python path accordingly.
This is crucial because users might rely on different versions of libraries that overlap with those used by the agent. By prioritizing their dependencies, we reduce the risk of introducing compatibility issues or breaking changes in the user's application.