### PR TITLE
chore: update the resource process attributes via using proxyResource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.57",
+    version="1.0.58",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="Tamir David",
     author_email="tamir@odigos.io",


### PR DESCRIPTION
This PR fixes incorrect process.* attributes (like process.pid) after fork.
It introduces a ProxyResource that updates process attributes lazily in the child instead of re-running full initialization.
The fork hook now only marks the proxy as dirty and restarts the OpAMP client, keeping it safe and lightweight.

emergency-ticket id: EMR-257
