### PR TITLE
Improve odiglet not response usecases

### DIFF
--- a/initializer/components.py
+++ b/initializer/components.py
@@ -51,7 +51,8 @@ def initialize_components(trace_exporters = False, span_processor = None):
 
         client = start_opamp_client(opamp_connection_event)
 
-        ## In case of error, e.g during the first connection to the OpAMP server, we will use the default value which is enable traces only.
+        ## In case of error, e.g during the first connection to the OpAMP server,
+        # we will use the default value which is enable traces only.
         if opamp_connection_event.error:
             supported_signals = {"traceSignal": True}
         else:
@@ -166,8 +167,10 @@ def start_opamp_client(event):
 
     client.start(python_version_supported)
 
-    # Wait for the opamp first message to be received for 30 seconds
-    event.event.wait(timeout=30)
+    # Wait for the opamp first message to be received
+    # Timeout based on maximum time for first message retry sequence to fail completely:
+    # 2 attempts × (5s HTTP timeout + 2s delay) - 2s (no delay after last attempt) + last message timeout + 1s buffer = 17s
+    event.event.wait(timeout=18)
 
     # Report the instrumentation libraries
     libraries = instrumentation_registry.get_instrumented_libraries()

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -169,7 +169,7 @@ def start_opamp_client(event):
 
     # Wait for the opamp first message to be received
     # Timeout based on maximum time for first message retry sequence to fail completely:
-    # 2 attempts × (5s HTTP timeout + 2s delay) - 2s (no delay after last attempt) + last message timeout + 1s buffer = 17s
+    # 2 attempts × (5s HTTP timeout + 2s delay) - 2s (no delay after last attempt) + last message timeout + 1s buffer = 18s
     event.event.wait(timeout=18)
 
     # Report the instrumentation libraries

--- a/opamp/health_status.py
+++ b/opamp/health_status.py
@@ -6,3 +6,4 @@ class AgentHealthStatus(str, Enum):
     UNSUPPORTED_RUNTIME_VERSION = "UnsupportedRuntimeVersion"
     TERMINATED = "ProcessTerminated"
     AGENT_FAILURE = "AgentFailure"
+    NO_CONNECTION_TO_OPAMP_SERVER = "NoConnectionToOpAMPServer"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.58",
+    version="1.0.59",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="Tamir David",
     author_email="tamir@odigos.io",


### PR DESCRIPTION
This PR improves the durability of the Python agent. Previously, the agent relied on the Odiglet responding to certain messages, but we cannot guarantee that this will always happen. This PR removes that assumption and makes the agent more resilient.

emergency-ticket id: EMR-524
