### PR TITLE
feat: add db.operation.name if parse it from the statement

### DIFF
--- a/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -101,7 +101,7 @@ def _wrap_create_engine(
                 enable_attribute_commenter,
             )
             return engine
-        
+
 
         EngineTracer(
             tracer,
@@ -235,7 +235,7 @@ class EngineTracer:
                 remove(weak_ref_target(), identifier, func)
         cls._remove_event_listener_params.clear()
 
-    def _operation_name(self, db_name, statement):
+    def _operation_name(self, db_name, statement, attrs=None):
         parts = []
         if isinstance(statement, str):
             # otel spec recommends against parsing SQL queries. We are not trying to parse SQL
@@ -244,9 +244,13 @@ class EngineTracer:
             # For some very special cases it might not record the correct statement if the SQL
             # dialect is too weird but in any case it shouldn't break anything.
             # Strip leading comments so we get the operation name.
-            parts.append(
-                self._leading_comment_remover.sub("", statement).split()[0]
-            )
+            operation = self._leading_comment_remover.sub("", statement).split()[0]
+            parts.append(operation)
+
+            # Set db.operation since we know this came from a valid statement
+            if attrs is not None:
+                attrs[SpanAttributes.DB_OPERATION] = operation.upper()
+
         if db_name:
             parts.append(db_name)
         if not parts:
@@ -287,8 +291,10 @@ class EngineTracer:
             attrs = _get_attributes_from_cursor(self.vendor, cursor, attrs)
 
         db_name = attrs.get(SpanAttributes.DB_NAME, "")
+        operation_name = self._operation_name(db_name, statement, attrs)
+
         span = self.tracer.start_span(
-            self._operation_name(db_name, statement),
+            operation_name,
             kind=trace.SpanKind.CLIENT,
         )
         with trace.use_span(span, end_on_exit=False):

--- a/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
+++ b/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/engine.py
@@ -249,7 +249,7 @@ class EngineTracer:
 
             # Set db.operation since we know this came from a valid statement
             if attrs is not None:
-                attrs[SpanAttributes.DB_OPERATION] = operation.upper()
+                attrs[SpanAttributes.DB_OPERATION] = operation
 
         if db_name:
             parts.append(db_name)

--- a/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
+++ b/instrumentations/opentelemetry-instrumentation-sqlalchemy/src/opentelemetry/instrumentation/sqlalchemy/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.52b1"
+__version__ = "0.52b2"

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'opentelemetry-instrumentation-requests==0.52b1',
         # When testing new overloaded integration add it in the following way to pull the custom tag from the local pypi repo
         # 'odigos-opentelemetry-instrumentation-sqlalchemy @ http://host.docker.internal:8080/packages/odigos_opentelemetry_instrumentation_sqlalchemy-0.52b1-py3-none-any.whl',
-        'odigos-opentelemetry-instrumentation-sqlalchemy==0.52b1',
+        'odigos-opentelemetry-instrumentation-sqlalchemy==0.52b2',
         'opentelemetry-instrumentation-sqlite3==0.52b1',
         'opentelemetry-instrumentation-starlette==0.52b1',
         'opentelemetry-instrumentation-tornado==0.52b1',


### PR DESCRIPTION
Fix of issue when the instrumentation override the span name but not set operation name, and users using Odigos `query-operation-detector`.
<img width="680" height="149" alt="image" src="https://github.com/user-attachments/assets/791fb639-5df1-4eec-a3b1-20274fe770f6" />

emergency-ticket id: EMR-797
