### PR TITLE
fix: avoid conflicting with other otel sdks

### DIFF
--- a/initializer/distro/__init__.py
+++ b/initializer/distro/__init__.py
@@ -1,4 +1,0 @@
-# To ensure user dependencies take precedence over those of the Odigos agent, we need to reorder the Python path accordingly.
-# This is crucial because users might rely on different versions of libraries that overlap with those used by the agent. By prioritizing their dependencies, we reduce the risk of introducing compatibility issues or breaking changes in the user's application.
-from ..lib_handling import reorder_python_path
-reorder_python_path()

--- a/requirements.txt
+++ b/requirements.txt
@@ -342,7 +342,7 @@ requests==2.32.3
     # via
     #   odigos-opentelemetry-python (setup.py)
     #   opentelemetry-exporter-otlp-proto-http
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   asgiref
     #   odigos-opentelemetry-python (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -342,7 +342,7 @@ requests==2.32.3
     # via
     #   odigos-opentelemetry-python (setup.py)
     #   opentelemetry-exporter-otlp-proto-http
-typing-extensions==4.14.0
+typing-extensions==4.12.2
     # via
     #   asgiref
     #   odigos-opentelemetry-python (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'protobuf==5.29.6',
         'importlib-metadata==6.0',
         'wrapt==1.17.3',
-        'typing-extensions==4.14.0',
+        'typing-extensions==4.12.2',
         'opentelemetry-exporter-otlp-proto-http==1.33.1',
         'opentelemetry-instrumentation==0.54b1',
         'opentelemetry-instrumentation-aio-pika==0.54b1',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.66",
+    version="1.0.67",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="odigos-io",
     author_email="support@odigos.io",
@@ -36,7 +36,7 @@ setup(
         'protobuf==5.29.6',
         'importlib-metadata==6.0',
         'wrapt==1.17.3',
-        'typing-extensions==4.12.2',
+        'typing-extensions==4.14.0',
         'opentelemetry-exporter-otlp-proto-http==1.33.1',
         'opentelemetry-instrumentation==0.54b1',
         'opentelemetry-instrumentation-aio-pika==0.54b1',


### PR DESCRIPTION
When a user application depends on a package that pulls in an older **opentelemetry-api** (e.g., via fastmcp or llama-index), the agent crashes during initialization with:
```
ImportError: cannot import name 'std_to_otel' from 'opentelemetry._logs'
```
**Root cause:** opentelemetry is a namespace package — its `__path__` is rebuilt from sys.path on every subpackage import. The distro python `__init__.py` called `reorder_python_path()` too early (before the agent's SDK imports), moving the agent's paths to the end of sys.path.
This caused `opentelemetry.__path__` to resolve the user's older API modules instead of the agent's, breaking internal SDK imports.
**Fix:** Remove the early `reorder_python_path()` from `distro/__init__.py`. The same call already exists in `components.py` where it runs after the agent's SDK imports succeed, so user dependencies still take precedence when the app starts.

emergency-ticket id: EMR-1262
