### PR TITLE
chore: reorder earlier and change MINIMUM_PYTHON_SUPPORTED_VERSION

### DIFF
--- a/agent/configurator/__init__.py
+++ b/agent/configurator/__init__.py
@@ -2,7 +2,7 @@ import opentelemetry.sdk._configuration as sdk_config
 from initializer.components import initialize_components
 
 
-MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 8)
+MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 9)
 
 class OdigosPythonConfigurator(sdk_config._BaseConfigurator):
     def _configure(self, **kwargs):

--- a/agent/setup.py
+++ b/agent/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 index_url = None
 
 install_requires = [
-    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.68"
+    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.69"
 ]
 
 setup(
     name="odigos-python-configurator",
-    version="1.0.68",
+    version="1.0.69",
     description="Odigos Configurator for Python OpenTelemetry Auto-Instrumentation",
     author="Tamir David",
     author_email="tamir@odigos.io",

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -7,6 +7,10 @@ import atexit
 import sys
 import os
 
+# Reorder the python sys.path to ensure that the user application's dependencies take precedence over the agent's dependencies.
+# This is necessary because the user application's dependencies may be incompatible with those used by the agent.
+reorder_python_path()
+
 import opentelemetry.sdk._configuration as sdk_config
 from .process_resource import OdigosProcessResourceDetector
 from opentelemetry.sdk.resources import Resource
@@ -26,13 +30,10 @@ from opamp.config import Config
 from opamp import opamp_registry
 from .distro import instrumentation_registry
 
-# Reorder the python sys.path to ensure that the user application's dependencies take precedence over the agent's dependencies.
-# This is necessary because the user application's dependencies may be incompatible with those used by the agent.
-reorder_python_path()
 
 from opamp.http_client import OpAMPHTTPClient, MockOpAMPClient
 
-MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 8)
+MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 9)
 
 
 def initialize_components(trace_exporters = False, span_processor = None):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="odigos-opentelemetry-python",
-    version="1.0.68",
+    version="1.0.69",
     description="Odigos Initializer for Python OpenTelemetry Components",
     author="odigos-io",
     author_email="support@odigos.io",


### PR DESCRIPTION
Move the reorder before otel imports to make sure we're not conflicting with another otel if exists.

emergency-ticket id: EMR-1312
