### PR TITLE
CORE-00: add a polling mechanism for docker build on CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,6 +99,24 @@ jobs:
           fi
           echo "✅ agent/pyproject.toml version and odigos-opentelemetry-python==${VERSION} are correct"
 
+      - name: Wait for PyPI availability
+        # The Docker build resolves dependencies from PyPI, but CDN propagation
+        # can lag behind the upload. Poll until the package is available.
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "⏳ Waiting for odigos-opentelemetry-python==${VERSION} on PyPI..."
+          for i in $(seq 1 12); do
+            if curl -sf "https://pypi.org/pypi/odigos-opentelemetry-python/${VERSION}/json" > /dev/null; then
+              echo "✅ Package available on PyPI"
+              exit 0
+            fi
+            echo "  Not yet available, retrying in 5s... (attempt $i/12)"
+            sleep 5
+          done
+          echo "❌ Package not available on PyPI after 60s"
+          exit 1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.71"
+version = "1.0.72"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.71",
+    "odigos-opentelemetry-python == 1.0.72",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.71"
+version = "1.0.72"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.71"
+version = "1.0.72"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1097,7 +1097,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.71"
+version = "1.0.72"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
Since we moved to UV, the docker build is too fast and sometimes the python package is not available yet on pypi.
Added a polling mechanism to check that the package is indeed on pypi.