### PR TITLE
build: use empty base image for community agent

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -5,7 +5,7 @@
 
 # IMPORTANT: If changing the Python version below, update the Python dependency shared object filenames
 # in odiglet/pkg/instrumentation/fs/agents.go (e.g., cpython-311 must match the Python version).
-FROM python:3.11.9 AS python-builder
+FROM python:3.11.9 AS python-community-build
 
 RUN pip install uv
 
@@ -19,3 +19,10 @@ COPY agent/ ./agent
 #   - publish.yaml, CI: PyPI (wheels are published before this Docker build runs)
 RUN sed -i '/\[tool\.uv\.sources\]/,/^$/d' agent/pyproject.toml
 RUN uv pip install ./agent/ --find-links ./agent/ --prerelease=allow --target workspace --system
+
+
+# Ultra-minimal base image - just for copying files
+FROM scratch
+WORKDIR /instrumentations
+
+COPY --from=python-community-build /python-instrumentation/workspace /instrumentations/python


### PR DESCRIPTION
Fixes: CORE-847

Currently, each agent repo publishes the runtime files that ends up in `/var/odigos` as a docker image. repositories usually start this image from scratch, so that it's light-weight and contains only what neccessary:

- Java [here](https://github.com/odigos-io/ebpf-java-instrumentation/blob/9e8e7426c34eddf3daddfc5d421cfac43e0f5b2c/Dockerfile.java-ebpf-instrumentations#L15) and [here](https://github.com/odigos-io/ebpf-java-instrumentation/blob/9e8e7426c34eddf3daddfc5d421cfac43e0f5b2c/otel_agent_extension/Dockerfile.java-enterprise#L9)
- `nodejs-enterprise` [here](https://github.com/odigos-io/ebpf-nodejs-instrumentation/blob/be4b2f804673e831b836c2327c0cb2ca670787c5/dtrace-injector/Dockerfile#L57)
- `nodejs-community` [here](https://github.com/odigos-io/opentelemetry-node/blob/ade4e71ddbcbb13e9d9bf1360e5a91e0e6e5bfd8/Dockerfile#L19)
- `php-community` [here](https://github.com/odigos-io/opentelemetry-php/blob/173989cb9048e918475f87b22505917d6a54ca4c/release.Dockerfile#L19)
- `ruby-community` [here](https://github.com/odigos-io/opentelemetry-ruby/blob/bd778130135b990a9d5e1add026f348de0d01ebb/Dockerfile#L21)

python is not aligned, which caused odiglet to download ~500Mb of base image instead of few mb, which makes it slow to build.

This PR align it to build a minimal image with just what needed, without adding burden to downstream consumers