### PR TITLE
fix: strip optional extras from dist-info METADATA to suppress false vuln flags

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -20,6 +20,12 @@ COPY agent/ ./agent
 RUN sed -i '/\[tool\.uv\.sources\]/,/^$/d' agent/pyproject.toml
 RUN uv pip install ./agent/ --find-links ./agent/ --prerelease=allow --target workspace --system
 
+# Remove optional (test/doc) extras from dist-info METADATA files.
+# Packages like zipp and importlib-metadata declare optional dependencies
+# on jaraco.* packages (e.g., jaraco.context, jaraco.functools) that are
+# never installed but cause false-positive vulnerability scanner flags.
+RUN find workspace -name 'METADATA' -path '*.dist-info/*' \
+    -exec sed -i '/^Requires-Dist:.*; extra ==/d' {} +
 
 # Ultra-minimal base image - just for copying files
 FROM scratch


### PR DESCRIPTION
## Summary

- Strip `Requires-Dist: ... ; extra == "..."` lines from dist-info METADATA files after `uv pip install` in `release.Dockerfile`
- Prevents vulnerability scanners from flagging `jaraco.context`, `jaraco.functools`, and other jaraco packages as vulnerabilities

## Problem

Packages like `zipp` (3.20.2) and `importlib-metadata` (6.0) declare optional dependencies on `jaraco.*` packages under `test`/`doc` extras in their dist-info METADATA files. These extras are **never installed** — they're only for development. However, vulnerability scanners trace `Requires-Dist` metadata transitively and flag `jaraco.context-5.3.0` as a vulnerability when the agent files are copied to the host via `CopyAgentsDirectoryToHost()`.

## Fix

A single `find`+`sed` step after `uv pip install` removes all optional extra dependency declarations from METADATA files. This is semantically correct — we never activate any extras at runtime.

#### Fixes RUN-701