### PR TITLE
ci: add vulnerability scan workflow using Grype

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -1,0 +1,35 @@
+# Scan for vulnerabilities in the Python instrumentation agent.
+#
+# Usage:
+# - Triggered on pull requests and manually via workflow_dispatch.
+# - Scans the source tree (excluding tests) for known vulnerabilities using Grype.
+
+name: Vulnerability Scan
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  vuln-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Remove non-production directories
+        run: |
+          DIRS=("tests")
+          for dir in "${DIRS[@]}"; do
+            if [ -d "$dir" ]; then
+              echo "Removing $dir directory"
+              rm -rf "$dir"
+            else
+              echo "Directory $dir does not exist, skipping."
+            fi
+          done
+
+      - name: Scan for vulnerabilities
+        uses: odigos-io/ci-core/vulnerabilities-scanner@main
+        with:
+          path: .
+          severity-cutoff: "CRITICAL, HIGH"

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -8,6 +8,11 @@ name: Vulnerability Scan
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag or branch to scan (optional)"
+        required: false
+        type: string
 
 jobs:
   vuln-scan:
@@ -15,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Remove non-production directories
         run: |


### PR DESCRIPTION
## Summary

- Add `vulnerability-scan.yaml` workflow that scans the source tree for known vulnerabilities
- Uses the shared `odigos-io/ci-core/vulnerabilities-scanner` composite action (Grype)
- Runs on PRs and manual dispatch
- Fails on CRITICAL or HIGH severity findings with available fixes
- Excludes `tests/` directory from scan

Fixes RUN-702