### PR TITLE
chore: handle namespaced deps

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.77"
+version = "1.0.78"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.77",
+    "odigos-opentelemetry-python == 1.0.78",
 ]
 
 [tool.uv.sources]

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -7,6 +7,19 @@ import atexit
 import sys
 import os
 
+
+# opentelemetry is a namespace package — Python merges all opentelemetry/
+# directories from sys.path into opentelemetry.__path__.  If the user app
+# bundles a different opentelemetry-api version, the user's copy can end up
+# first and break agent imports (e.g. ImportError on std_to_otel).
+# Fix: reorder opentelemetry.__path__ so agent paths are always searched first.
+import opentelemetry
+
+_agent_prefix = ('/var/odigos/', '/etc/odigos-vmagent/')
+_agent_otel = [p for p in opentelemetry.__path__ if any(p.startswith(pfx) for pfx in _agent_prefix)]
+_other_otel = [p for p in opentelemetry.__path__ if not any(p.startswith(pfx) for pfx in _agent_prefix)]
+opentelemetry.__path__[:] = _agent_otel + _other_otel
+
 import opentelemetry.sdk._configuration as sdk_config
 from .process_resource import OdigosProcessResourceDetector
 from opentelemetry.sdk.resources import Resource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.77"
+version = "1.0.78"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -932,7 +932,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.77"
+version = "1.0.78"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1095,7 +1095,7 @@ provides-extras = ["test"]
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.77"
+version = "1.0.78"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
Fix namespace package collision between the Odigos agent and user applications.

When a user app bundles a different opentelemetry-api version, Python's namespace package merge can resolve opentelemetry.__path__ with the user's copy first, causing ImportError on agent-internal symbols like std_to_otel. The fix reorders opentelemetry.__path__ before any SDK imports so agent-owned directories are always searched first.

emergency-ticket id: EMR-1500
