### PR TITLE
CORE-967 | chore: use container_config instead of sdk config in python

### DIFF
--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -147,8 +147,8 @@ class OpAMPHTTPClient:
                                     # The default config is preloaded when the EBPFSpanProcessor is initialized
                                     pass
 
-                        sdk_config = utils.get_sdk_config(first_message_server_to_agent.remote_config.config.config_map)
-                        self.signals = utils.parse_first_message_signals(sdk_config)
+                        container_config = utils.get_container_config(first_message_server_to_agent.remote_config.config.config_map)
+                        self.signals = utils.parse_first_message_signals(container_config)
 
                         # Store initial sampler config for direct access
                         remote_config = self.get_remote_config(first_message_server_to_agent)

--- a/opamp/utils.py
+++ b/opamp/utils.py
@@ -1,26 +1,26 @@
 import json
 
-def get_sdk_config(config_map):
+def get_container_config(config_map):
     """
-    Extracts and parses the SDK configuration from the config map.
+    Extracts and parses the container configuration from the config map.
     """
-    if "SDK" not in config_map:
+    if "container_config" not in config_map:
         return {}
 
     try:
-        return json.loads(config_map["SDK"].body)
+        return json.loads(config_map["container_config"].body)
     except json.JSONDecodeError:
         return {}
 
 
-
-def parse_first_message_signals(sdk_config): # type: ignore
+def parse_first_message_signals(container_config): # type: ignore
     """
-    Parses the trace, logs, and metrics signals configuration from the SDK config.
+    Parses the trace, logs, and metrics signals from the container config.
+    Signal is considered enabled if its key exists in the config.
     """
 
     return {
-        "traceSignal": sdk_config.get("traceSignal", {}).get("enabled", False),
-        "metricsSignal": sdk_config.get("metricsSignal", {}).get("enabled", False),
-        "logsSignal": sdk_config.get("logsSignal", {}).get("enabled", False),
+        "traceSignal": "traces" in container_config,
+        "metricsSignal": "metrics" in container_config,
+        "logsSignal": "logs" in container_config,
     }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Before we deprecated sdkconfig we need to make sure all agents including python will use the container config for some time.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
