### PR TITLE
CORE-943 | feat: support record mode in python agent

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.81"
+version = "1.0.82"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.81",
+    "odigos-opentelemetry-python == 1.0.82",
 ]
 
 [tool.uv.sources]

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -48,7 +48,6 @@ from opamp.config import Config
 from opamp import opamp_registry
 from .distro import instrumentation_registry
 
-
 from opamp.http_client import OpAMPHTTPClient, MockOpAMPClient
 
 MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 9)

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -56,11 +56,12 @@ _odigos_sampler = None
 
 ALWAYS_RECORD_ONLY = StaticSampler(Decision.RECORD_ONLY)
 
-def initialize_components(trace_exporters = False, span_processor = None):
+
+def initialize_components(trace_exporters=False, span_processor=None):
     # Ensure each child process after fork gets a fresh OpAMP client
     # and correct process.* resource attributes.
     os.register_at_fork(
-    after_in_child=_after_in_child,
+        after_in_child=_after_in_child,
     )  # pylint: disable=protected-access
 
     handle_instrumenation_of_sub_processes()
@@ -69,7 +70,6 @@ def initialize_components(trace_exporters = False, span_processor = None):
     client = None
 
     try:
-
         client = start_opamp_client(opamp_connection_event)
 
         ## In case of error, e.g during the first connection to the OpAMP server,
@@ -92,7 +92,6 @@ def initialize_components(trace_exporters = False, span_processor = None):
             except AttributeError:
                 initial_remote_config = None
 
-
         handle_django_instrumentation()
 
         auto_resource = {
@@ -101,17 +100,19 @@ def initialize_components(trace_exporters = False, span_processor = None):
         }
 
         base_resource = (
-            OdigosProcessResourceDetector(client.pid).detect()
-            .merge(OTELResourceDetector().detect())
-            .merge(Resource.create(auto_resource))
+            OdigosProcessResourceDetector(client.pid).detect().merge(OTELResourceDetector().detect()).merge(Resource.create(auto_resource))
         )
 
         # Wrap in proxy so child processes can refresh automatically
         resource = ProxyResource(base_resource, OdigosProcessResourceDetector)
 
         odigos_sampler = initialize_traces_if_enabled(
-            trace_exporters, resource, span_processor,
-            supported_signals, initial_sampler_config, initial_remote_config,
+            trace_exporters,
+            resource,
+            span_processor,
+            supported_signals,
+            initial_sampler_config,
+            initial_remote_config,
         )
         if odigos_sampler is not None:
             client.sampler = odigos_sampler
@@ -127,16 +128,20 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # Make sure the distro modules are reloaded even if an exception is raised.
         reload_distro_modules()
 
+
 def initialize_traces_if_enabled(
-    trace_exporters, resource, span_processor=None,
-    signals=None, initial_sampler_config=None, initial_remote_config=None,
+    trace_exporters,
+    resource,
+    span_processor=None,
+    signals=None,
+    initial_sampler_config=None,
+    initial_remote_config=None,
 ):
     global _odigos_sampler
     # In case collectors signals support receiving traces, initialize the tracer provider with the exporters
     traces_enabled = signals.get("traceSignal", False)
 
     if traces_enabled:
-
         odigos_sampler = OdigosSampler()
         _odigos_sampler = odigos_sampler
         sampler = ParentBased(odigos_sampler, remote_parent_not_sampled=ALWAYS_RECORD_ONLY, local_parent_not_sampled=ALWAYS_RECORD_ONLY)
@@ -158,9 +163,7 @@ def initialize_traces_if_enabled(
 
             for _, exporter_class in exporters.items():
                 exporter_args = {}
-                provider.add_span_processor(
-                    BatchSpanProcessor(exporter_class(**exporter_args))
-                )
+                provider.add_span_processor(BatchSpanProcessor(exporter_class(**exporter_args)))
 
         # Exporting using EBPF
         else:
@@ -178,6 +181,7 @@ def initialize_traces_if_enabled(
         return odigos_sampler
 
     return None
+
 
 def initialize_metrics_if_enabled(resource, signals):
     # Currently we're not exporting metrics using the OTEL exporter.
@@ -215,7 +219,6 @@ def start_opamp_client(event):
 
     python_version_supported = is_supported_python_version()
 
-
     client.start(python_version_supported)
 
     # Wait for the opamp first message to be received
@@ -247,6 +250,7 @@ def start_opamp_client(event):
 
     return client
 
+
 def update_agent_config(conf: Config):
     """
     The function `update_agent_config` checks for a tracer provider and updates its configuration using
@@ -271,9 +275,7 @@ def update_agent_config(conf: Config):
         if 'traces' in conf.sample_config and 'headSampling' in conf.sample_config['traces']:
             head_sampling_config = conf.sample_config['traces']['headSampling']
 
-        if head_sampling_config and (
-            head_sampling_config.get('noisyOperations') is not None
-        ):
+        if head_sampling_config and (head_sampling_config.get('noisyOperations') is not None):
             valid_config = head_sampling_config
         else:
             valid_config = None
@@ -281,6 +283,7 @@ def update_agent_config(conf: Config):
         # Apply config to sampler - sampler will always exist when this callback is called
         # because update_agent_config is only called from OpAMP worker thread after sampler creation
         from opamp import opamp_registry
+
         client = opamp_registry.get_client()
 
         if client and hasattr(client, 'sampler') and client.sampler:
@@ -298,18 +301,16 @@ def update_agent_config(conf: Config):
     # If you attached only one BatchSpanProcessor, _active_span_processor
     # *is* that object.  If you attached several, it is a MultiSpanProcessor
     # that wraps them in ._span_processors.
-    processors = (
-        active_proc._span_processors
-        if hasattr(active_proc, "_span_processors")
-        else [active_proc]
-    )
+    processors = active_proc._span_processors if hasattr(active_proc, "_span_processors") else [active_proc]
 
     for proc in processors:
         if hasattr(proc, "update_config"):
             proc.update_config(conf)
 
+
 def is_supported_python_version():
     return sys.version_info >= MINIMUM_PYTHON_SUPPORTED_VERSION
+
 
 def handle_instrumenation_of_sub_processes():
     # Resolves a path management issue introduced by OpenTelemetry's sitecustomize implementation.

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.resources import OTELResourceDetector
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import set_tracer_provider, get_tracer_provider
-from opentelemetry.sdk.trace.sampling import ParentBased
+from opentelemetry.sdk.trace.sampling import ParentBased, Decision, StaticSampler
 
 
 # Move Odigos agent paths to the end of sys.path so the application's packages are
@@ -55,6 +55,7 @@ MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 9)
 
 _odigos_sampler = None
 
+ALWAYS_RECORD_ONLY = StaticSampler(Decision.RECORD_ONLY)
 
 def initialize_components(trace_exporters = False, span_processor = None):
     # Ensure each child process after fork gets a fresh OpAMP client
@@ -76,16 +77,21 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # we will use the default value which is enable traces only.
         if opamp_connection_event.error:
             supported_signals = {"traceSignal": True}
-            initial_sampler_config = None  # No config available due to connection error
+            initial_sampler_config = None
+            initial_remote_config = None
         else:
             supported_signals = client.signals
 
-            # Get initial sampler config directly from client (only when connection is successful)
+            # Get initial configs directly from client (only when connection is successful)
             try:
                 initial_sampler_config = client.get_initial_sampler_config()
             except AttributeError:
-                # Fallback to None to avoid errors
                 initial_sampler_config = None
+
+            try:
+                initial_remote_config = client.get_initial_remote_config()
+            except AttributeError:
+                initial_remote_config = None
 
 
         handle_django_instrumentation()
@@ -104,7 +110,7 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # Wrap in proxy so child processes can refresh automatically
         resource = ProxyResource(base_resource, OdigosProcessResourceDetector)
 
-        odigos_sampler = initialize_traces_if_enabled(trace_exporters, resource, span_processor, supported_signals, initial_sampler_config)
+        odigos_sampler = initialize_traces_if_enabled(trace_exporters, resource, span_processor, supported_signals, initial_sampler_config, initial_remote_config)
         if odigos_sampler is not None:
             client.sampler = odigos_sampler
 
@@ -119,7 +125,7 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # Make sure the distro modules are reloaded even if an exception is raised.
         reload_distro_modules()
 
-def initialize_traces_if_enabled(trace_exporters, resource, span_processor = None, signals = None, initial_sampler_config = None):
+def initialize_traces_if_enabled(trace_exporters, resource, span_processor = None, signals = None, initial_sampler_config = None, initial_remote_config = None):
     global _odigos_sampler
     # In case collectors signals support receiving traces, initialize the tracer provider with the exporters
     traces_enabled = signals.get("traceSignal", False)
@@ -128,7 +134,7 @@ def initialize_traces_if_enabled(trace_exporters, resource, span_processor = Non
 
         odigos_sampler = OdigosSampler()
         _odigos_sampler = odigos_sampler
-        sampler = ParentBased(odigos_sampler)
+        sampler = ParentBased(odigos_sampler, remote_parent_not_sampled=ALWAYS_RECORD_ONLY, local_parent_not_sampled=ALWAYS_RECORD_ONLY)
 
         # Apply initial sampler config if provided (from OpAMP first message)
         if initial_sampler_config is not None:
@@ -157,6 +163,12 @@ def initialize_traces_if_enabled(trace_exporters, resource, span_processor = Non
             set_tracer_provider(provider)
             if span_processor is not None:
                 provider.add_span_processor(span_processor)
+
+            # Bootstrap processor config from the first OpAMP message.
+            # The update_conf_cb fires before the TracerProvider exists,
+            # so the processor misses the initial config; apply it now.
+            if initial_remote_config is not None and span_processor is not None and hasattr(span_processor, 'update_config'):
+                span_processor.update_config(initial_remote_config)
 
         return odigos_sampler
 

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -110,7 +110,10 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # Wrap in proxy so child processes can refresh automatically
         resource = ProxyResource(base_resource, OdigosProcessResourceDetector)
 
-        odigos_sampler = initialize_traces_if_enabled(trace_exporters, resource, span_processor, supported_signals, initial_sampler_config, initial_remote_config)
+        odigos_sampler = initialize_traces_if_enabled(
+            trace_exporters, resource, span_processor,
+            supported_signals, initial_sampler_config, initial_remote_config,
+        )
         if odigos_sampler is not None:
             client.sampler = odigos_sampler
 
@@ -125,7 +128,10 @@ def initialize_components(trace_exporters = False, span_processor = None):
         # Make sure the distro modules are reloaded even if an exception is raised.
         reload_distro_modules()
 
-def initialize_traces_if_enabled(trace_exporters, resource, span_processor = None, signals = None, initial_sampler_config = None, initial_remote_config = None):
+def initialize_traces_if_enabled(
+    trace_exporters, resource, span_processor=None,
+    signals=None, initial_sampler_config=None, initial_remote_config=None,
+):
     global _odigos_sampler
     # In case collectors signals support receiving traces, initialize the tracer provider with the exporters
     traces_enabled = signals.get("traceSignal", False)

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -27,7 +27,6 @@ from opentelemetry.sdk.resources import OTELResourceDetector
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import set_tracer_provider, get_tracer_provider
-from opentelemetry.sdk.trace.sampling import ParentBased, Decision, StaticSampler
 
 
 # Move Odigos agent paths to the end of sys.path so the application's packages are
@@ -49,12 +48,11 @@ from opamp import opamp_registry
 from .distro import instrumentation_registry
 
 from opamp.http_client import OpAMPHTTPClient, MockOpAMPClient
+from opamp.utils import parse_first_message_signals
 
 MINIMUM_PYTHON_SUPPORTED_VERSION = (3, 9)
 
 _odigos_sampler = None
-
-ALWAYS_RECORD_ONLY = StaticSampler(Decision.RECORD_ONLY)
 
 
 def initialize_components(trace_exporters=False, span_processor=None):
@@ -75,11 +73,13 @@ def initialize_components(trace_exporters=False, span_processor=None):
         ## In case of error, e.g during the first connection to the OpAMP server,
         # we will use the default value which is enable traces only.
         if opamp_connection_event.error:
+            container_config = None
             supported_signals = {"traceSignal": True}
             initial_sampler_config = None
             initial_remote_config = None
         else:
-            supported_signals = client.signals
+            container_config = client.container_config
+            supported_signals = parse_first_message_signals(container_config)
 
             # Get initial configs directly from client (only when connection is successful)
             try:
@@ -144,7 +144,6 @@ def initialize_traces_if_enabled(
     if traces_enabled:
         odigos_sampler = OdigosSampler()
         _odigos_sampler = odigos_sampler
-        sampler = ParentBased(odigos_sampler, remote_parent_not_sampled=ALWAYS_RECORD_ONLY, local_parent_not_sampled=ALWAYS_RECORD_ONLY)
 
         # Apply initial sampler config if provided (from OpAMP first message)
         if initial_sampler_config is not None:
@@ -152,7 +151,7 @@ def initialize_traces_if_enabled(
 
         # Exporting using exporters
         if trace_exporters:
-            provider = TracerProvider(resource=resource, sampler=sampler)
+            provider = TracerProvider(resource=resource, sampler=odigos_sampler)
             id_generator_name = sdk_config._get_id_generator()
             id_generator = sdk_config._import_id_generator(id_generator_name)
             provider.id_generator = id_generator
@@ -167,7 +166,7 @@ def initialize_traces_if_enabled(
 
         # Exporting using EBPF
         else:
-            provider = TracerProvider(resource=resource, sampler=sampler)
+            provider = TracerProvider(resource=resource, sampler=odigos_sampler)
             set_tracer_provider(provider)
             if span_processor is not None:
                 provider.add_span_processor(span_processor)
@@ -275,11 +274,6 @@ def update_agent_config(conf: Config):
         if 'traces' in conf.sample_config and 'headSampling' in conf.sample_config['traces']:
             head_sampling_config = conf.sample_config['traces']['headSampling']
 
-        if head_sampling_config and (head_sampling_config.get('noisyOperations') is not None):
-            valid_config = head_sampling_config
-        else:
-            valid_config = None
-
         # Apply config to sampler - sampler will always exist when this callback is called
         # because update_agent_config is only called from OpAMP worker thread after sampler creation
         from opamp import opamp_registry
@@ -287,7 +281,7 @@ def update_agent_config(conf: Config):
         client = opamp_registry.get_client()
 
         if client and hasattr(client, 'sampler') and client.sampler:
-            client.sampler.update_config(valid_config)
+            client.sampler.update_config(head_sampling_config)
         else:
             # This should not happen in normal operation
             pass

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -6,7 +6,7 @@ from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult, _get_parent_trace_state
 from opentelemetry.semconv.attributes import http_attributes as http_attributes_semconv
 from opentelemetry.semconv.attributes import server_attributes as server_attributes_semconv
-from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.trace import Link, SpanKind, TraceState, get_current_span
 from opentelemetry.util.types import Attributes
 
 from initializer.schemas.sampling import (
@@ -30,6 +30,11 @@ class OdigosSampler(Sampler):
         self._lock = Lock()
         self._config: Optional[HeadSamplingConfig] = None
 
+    def _not_sampled_decision(self) -> Decision:
+        if self._config and self._config.get('spanMetricsMode') == "all-spans":
+            return Decision.RECORD_ONLY
+        return Decision.DROP
+
     def _trace_id_based_sampling(self, trace_id: int, percentage_to_sample: float) -> bool:
         """Mimic OpenTelemetry's trace ID-based sampling logic with 64-bit range."""
         # Since percentage to sample is in percents and we need a fraction, divide by 100
@@ -52,6 +57,19 @@ class OdigosSampler(Sampler):
     ) -> "SamplingResult":
         attributes = attributes or {}
         with self._lock:
+            parent_span_context = get_current_span(
+                parent_context
+            ).get_span_context()
+
+            # Parent-based logic taken from upstream ParentBased sampler so we can
+            # decide to DROP or RECORD_ONLY based on the recordMode configuration.
+            # Remote/local parent distinction is removed because both paths used the
+            # same not-sampled decision.
+            if parent_span_context is not None and parent_span_context.is_valid:
+                if parent_span_context.trace_flags.sampled:
+                    return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=_get_parent_trace_state(parent_context))
+                else:
+                    return SamplingResult(self._not_sampled_decision(), trace_state=_get_parent_trace_state(parent_context))
             # sampler_logger.debug(f'Running Should_sample a span with the following attributes: {attributes}')
 
             if self._config is None:
@@ -109,7 +127,7 @@ class OdigosSampler(Sampler):
                     return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=trace_state)
                 else:
                     # sampler_logger.debug(f'Trace [{trace_id}] is dropped with lowest percentage {lowest_percentage}')
-                    return SamplingResult(Decision.RECORD_ONLY, trace_state=trace_state)
+                    return SamplingResult(self._not_sampled_decision(), trace_state=trace_state)
 
             # sampler_logger.debug('No noisy operation matched, sampling the trace')
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=_get_parent_trace_state(parent_context))
@@ -199,7 +217,6 @@ class OdigosSampler(Sampler):
 
     def update_config(self, new_config):
         with self._lock:
-            # sampler_logger.debug(f'Updating the configuration with the new configuration: {new_config}')
             self._config = new_config
 
     def build_tracestate(

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -109,7 +109,7 @@ class OdigosSampler(Sampler):
                     return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=trace_state)
                 else:
                     # sampler_logger.debug(f'Trace [{trace_id}] is dropped with lowest percentage {lowest_percentage}')
-                    return SamplingResult(Decision.DROP, trace_state=trace_state)
+                    return SamplingResult(Decision.RECORD_ONLY, trace_state=trace_state)
 
             # sampler_logger.debug('No noisy operation matched, sampling the trace')
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=_get_parent_trace_state(parent_context))

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -57,9 +57,7 @@ class OdigosSampler(Sampler):
     ) -> "SamplingResult":
         attributes = attributes or {}
         with self._lock:
-            parent_span_context = get_current_span(
-                parent_context
-            ).get_span_context()
+            parent_span_context = get_current_span(parent_context).get_span_context()
 
             # Parent-based logic taken from upstream ParentBased sampler so we can
             # decide to DROP or RECORD_ONLY based on the recordMode configuration.

--- a/initializer/schemas/sampling.py
+++ b/initializer/schemas/sampling.py
@@ -36,4 +36,5 @@ class NoisyOperation(TypedDict, total=False):
 
 class HeadSamplingConfig(TypedDict, total=False):
     dryRun: bool
+    spanMetricsMode: str
     noisyOperations: list[NoisyOperation]

--- a/opamp/config.py
+++ b/opamp/config.py
@@ -4,22 +4,25 @@ from typing import Any, Dict, Type, TypeVar, get_type_hints
 
 T = TypeVar("T")
 
+
 ###             Configuration structs           ###
 class DefaultNoneMixin:
-    #__getattr__ is only invoked when the normal attribute lookup (__dict__, class attributes, etc.) fails.
+    # __getattr__ is only invoked when the normal attribute lookup (__dict__, class attributes, etc.) fails.
     # Prevent raising a ValueError when accessing a non existing key
     # It'll save us multiple try catch blocks in the future
     def __getattr__(self, name: str):
         return None
 
+
 @dataclass
 class CodeAttributes(DefaultNoneMixin):
-    column:      bool = False
-    file_path:   bool = False
-    function:    bool = False
+    column: bool = False
+    file_path: bool = False
+    function: bool = False
     line_number: bool = False
-    namespace:   bool = False
+    namespace: bool = False
     stack_trace: bool = False
+
 
 @dataclass
 class Config(DefaultNoneMixin):
@@ -27,12 +30,15 @@ class Config(DefaultNoneMixin):
     sample_config: Dict[str, Any] = field(default_factory=dict)
     span_metrics_mode: str = None
 
+
 ###             Helpers             ###
+
 
 def camel_to_snake(name: str) -> str:
     """Convert camelCase or PascalCase to snake_case."""
     s1 = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
     return s1.lower()
+
 
 def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
     """

--- a/opamp/config.py
+++ b/opamp/config.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass, fields, field
-from typing import Any, Dict, Type, TypeVar, get_type_hints
+from typing import Any, Dict, Optional, Type, TypeVar, get_type_hints
 
 T = TypeVar("T")
 
@@ -28,7 +28,7 @@ class CodeAttributes(DefaultNoneMixin):
 class Config(DefaultNoneMixin):
     code_attributes: CodeAttributes = field(default_factory=CodeAttributes)
     sample_config: Dict[str, Any] = field(default_factory=dict)
-    span_metrics_mode: str = None
+    span_metrics_mode: Optional[str] = None
 
 
 ###             Helpers             ###

--- a/opamp/config.py
+++ b/opamp/config.py
@@ -25,6 +25,7 @@ class CodeAttributes(DefaultNoneMixin):
 class Config(DefaultNoneMixin):
     code_attributes: CodeAttributes = field(default_factory=CodeAttributes)
     sample_config: Dict[str, Any] = field(default_factory=dict)
+    span_metrics_mode: str = None
 
 ###             Helpers             ###
 

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -51,6 +51,7 @@ class OpAMPHTTPClient:
         self.pid = os.getpid()
         self.update_conf_cb = None # Callback for configuration updates in the processor
         self._initial_sampler_config = None # Store initial sampler config for direct access
+        self._initial_remote_config = None # Store initial full Config for processor bootstrap
 
     def __repr__(self):
         return f"<OpAMPHTTPClient instance_uid={self.instance_uid} pid={self.pid}>"
@@ -150,9 +151,10 @@ class OpAMPHTTPClient:
                         container_config = utils.get_container_config(first_message_server_to_agent.remote_config.config.config_map)
                         self.signals = utils.parse_first_message_signals(container_config)
 
-                        # Store initial sampler config for direct access
+                        # Store initial configs for direct access (TracerProvider doesn't exist yet)
                         remote_config = self.get_remote_config(first_message_server_to_agent)
                         self._initial_sampler_config = self._extract_sampler_config(remote_config)
+                        self._initial_remote_config = remote_config
 
                         # Send healthy message to OpAMP server
                         agent_health = self.get_agent_health(component_health=True, status=AgentHealthStatus.HEALTHY.value)
@@ -165,7 +167,6 @@ class OpAMPHTTPClient:
                         return
 
             except Exception as e:
-                # opamp_logger.error(f"Attempt {attempt}/{max_retries} failed. Error sending full state to OpAMP server: {e}")
                 pass
 
             if attempt < max_retries:
@@ -294,6 +295,11 @@ class OpAMPHTTPClient:
         sample_config = decoded_map.get("container_config", None)
         if sample_config is not None:
             config.sample_config = sample_config
+
+            try:
+                config.span_metrics_mode = sample_config['traces']['headSampling']['spanMetricsMode']
+            except (KeyError, TypeError):
+                pass
 
         return config
 
@@ -462,6 +468,10 @@ class OpAMPHTTPClient:
         """Get the sampler config from the initial OpAMP message"""
         return self._initial_sampler_config
 
+    def get_initial_remote_config(self):
+        """Get the full Config from the initial OpAMP message"""
+        return self._initial_remote_config
+
 
 # Mock client class for non-OpAMP installations
 # This class simulates the OpAMP client when the OpAMP server is not available.
@@ -475,6 +485,10 @@ class MockOpAMPClient:
 
     def get_initial_sampler_config(self):
         """Mock client has no sampler config"""
+        return None
+
+    def get_initial_remote_config(self):
+        """Mock client has no remote config"""
         return None
 
     def shutdown(self, custom_failure_message=None):

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -33,8 +33,9 @@ _debugger_instance = None
 env_var_mappings = {
     "ODIGOS_WORKLOAD_NAMESPACE": ResourceAttributes.K8S_NAMESPACE_NAME,
     "ODIGOS_CONTAINER_NAME": ResourceAttributes.K8S_CONTAINER_NAME,
-    "ODIGOS_POD_NAME": ResourceAttributes.K8S_POD_NAME
+    "ODIGOS_POD_NAME": ResourceAttributes.K8S_POD_NAME,
 }
+
 
 class OpAMPHTTPClient:
     def __init__(self, opamp_connection_event, condition: threading.Condition):
@@ -47,18 +48,17 @@ class OpAMPHTTPClient:
         self.next_sequence_num = 0
         self.instance_uid = uuid7().__str__()
         self.remote_config_status = None
-        self.sampler = None # OdigosSampler instance
+        self.sampler = None  # OdigosSampler instance
         self.pid = os.getpid()
-        self.update_conf_cb = None # Callback for configuration updates in the processor
-        self._initial_sampler_config = None # Store initial sampler config for direct access
-        self._initial_remote_config = None # Store initial full Config for processor bootstrap
+        self.update_conf_cb = None  # Callback for configuration updates in the processor
+        self._initial_sampler_config = None  # Store initial sampler config for direct access
+        self._initial_remote_config = None  # Store initial full Config for processor bootstrap
 
     def __repr__(self):
         return f"<OpAMPHTTPClient instance_uid={self.instance_uid} pid={self.pid}>"
 
     def start(self, python_version_supported: bool = None):
         if not python_version_supported:
-
             python_version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
             error_message = f"Opentelemetry SDK require Python in version 3.8 or higher [{python_version} is not supported]"
 
@@ -258,16 +258,9 @@ class OpAMPHTTPClient:
         component_health_map = {}
 
         for lib_name, lib_details in instrumented_libraries.items():
-            component_health_map[lib_name] = opamp_pb2.ComponentHealth(
-                healthy=True,
-                status=json.dumps(lib_details)
-            )
+            component_health_map[lib_name] = opamp_pb2.ComponentHealth(healthy=True, status=json.dumps(lib_details))
 
-        health_msg = opamp_pb2.ComponentHealth(
-            healthy=True,
-            status="instrumentation libraries report",
-            component_health_map=component_health_map
-        )
+        health_msg = opamp_pb2.ComponentHealth(healthy=True, status="instrumentation libraries report", component_health_map=component_health_map)
 
         self.send_agent_to_server_message(opamp_pb2.AgentToServer(health=health_msg))
 
@@ -313,7 +306,7 @@ class OpAMPHTTPClient:
 
         inner = decoded_map.get("", None)
         if inner is None:
-            config = Config() # Return default values for config
+            config = Config()  # Return default values for config
         else:
             config = from_dict(Config, inner)
 
@@ -329,7 +322,7 @@ class OpAMPHTTPClient:
 
         return config
 
-    def send_heartbeat(self) -> opamp_pb2.ServerToAgent: # type: ignore
+    def send_heartbeat(self) -> opamp_pb2.ServerToAgent:  # type: ignore
         # opamp_logger.debug("Sending heartbeat to OpAMP server...")
         try:
             agent_to_server = opamp_pb2.AgentToServer(remote_config_status=self.remote_config_status)
@@ -337,7 +330,7 @@ class OpAMPHTTPClient:
         except requests_odigos.RequestException:
             pass
 
-    def get_agent_description(self) -> opamp_pb2.AgentDescription: # type: ignore
+    def get_agent_description(self) -> opamp_pb2.AgentDescription:  # type: ignore
         # The "DISABLE_OPAMP_CLIENT" environment variable is defined only in our VMs environments.
         # Here we use it exclusively to distinguish between virtual machine and Kubernetes environments.
         #
@@ -356,42 +349,24 @@ class OpAMPHTTPClient:
             process_id_key = PROCESS_VPID
 
         identifying_attributes = [
-            anyvalue_pb2.KeyValue(
-                key=ResourceAttributes.SERVICE_INSTANCE_ID,
-                value=anyvalue_pb2.AnyValue(string_value=self.instance_uid)
-            ),
-            anyvalue_pb2.KeyValue(
-                key=process_id_key,
-                value=anyvalue_pb2.AnyValue(int_value=self.pid)
-            ),
-            anyvalue_pb2.KeyValue(
-                key=ResourceAttributes.TELEMETRY_SDK_LANGUAGE,
-                value=anyvalue_pb2.AnyValue(string_value="python")
-            )
+            anyvalue_pb2.KeyValue(key=ResourceAttributes.SERVICE_INSTANCE_ID, value=anyvalue_pb2.AnyValue(string_value=self.instance_uid)),
+            anyvalue_pb2.KeyValue(key=process_id_key, value=anyvalue_pb2.AnyValue(int_value=self.pid)),
+            anyvalue_pb2.KeyValue(key=ResourceAttributes.TELEMETRY_SDK_LANGUAGE, value=anyvalue_pb2.AnyValue(string_value="python")),
         ]
 
         # Add additional attributes from environment variables
         for env_var, attribute_key in env_var_mappings.items():
             value = os.environ.get(env_var)
             if value:
-                identifying_attributes.append(
-                    anyvalue_pb2.KeyValue(
-                        key=attribute_key,
-                        value=anyvalue_pb2.AnyValue(string_value=value)
-                    )
-                )
+                identifying_attributes.append(anyvalue_pb2.KeyValue(key=attribute_key, value=anyvalue_pb2.AnyValue(string_value=value)))
 
-        return opamp_pb2.AgentDescription(
-            identifying_attributes=identifying_attributes,
-            non_identifying_attributes=[]
-        )
+        return opamp_pb2.AgentDescription(identifying_attributes=identifying_attributes, non_identifying_attributes=[])
 
-    def get_agent_disconnect(self) -> opamp_pb2.AgentDisconnect: # type: ignore
+    def get_agent_disconnect(self) -> opamp_pb2.AgentDisconnect:  # type: ignore
         return opamp_pb2.AgentDisconnect()
 
-    def get_agent_health(self, component_health: bool = None, last_error : str = None, status: str = None) -> opamp_pb2.ComponentHealth: # type: ignore
-        health = opamp_pb2.ComponentHealth(
-        )
+    def get_agent_health(self, component_health: bool = None, last_error: str = None, status: str = None) -> opamp_pb2.ComponentHealth:  # type: ignore
+        health = opamp_pb2.ComponentHealth()
         if component_health is not None:
             health.healthy = component_health
         if last_error is not None:
@@ -401,8 +376,7 @@ class OpAMPHTTPClient:
 
         return health
 
-
-    def send_agent_to_server_message(self, message: opamp_pb2.AgentToServer) -> opamp_pb2.ServerToAgent: # type: ignore
+    def send_agent_to_server_message(self, message: opamp_pb2.AgentToServer) -> opamp_pb2.ServerToAgent:  # type: ignore
 
         message.instance_uid = self.instance_uid.encode('utf-8')
         message.sequence_num = self.next_sequence_num
@@ -469,7 +443,7 @@ class OpAMPHTTPClient:
 
         self.send_agent_to_server_message(disconnect_message)
 
-    def update_remote_config_status(self, server_to_agent: opamp_pb2.ServerToAgent) -> bool: # type: ignore
+    def update_remote_config_status(self, server_to_agent: opamp_pb2.ServerToAgent) -> bool:  # type: ignore
         if server_to_agent.HasField("remote_config"):
             remote_config_hash = server_to_agent.remote_config.config_hash
             remote_config_status = opamp_pb2.RemoteConfigStatus(last_remote_config_hash=remote_config_hash)
@@ -492,9 +466,7 @@ class OpAMPHTTPClient:
         head_sampling_config = remote_config.sample_config['traces']['headSampling']
 
         # Check if we have valid sampling config (same validation as update_agent_config)
-        if head_sampling_config and (
-            head_sampling_config.get('noisyOperations') is not None
-        ):
+        if head_sampling_config and (head_sampling_config.get('noisyOperations') is not None):
             return head_sampling_config
         else:
             return None

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -102,7 +102,11 @@ class OpAMPHTTPClient:
         agent_disconnect = self.get_agent_disconnect()
         agent_failure_message.agent_disconnect.CopyFrom(agent_disconnect)
 
-        agent_health = self.get_agent_health(component_health=component_health, last_error=error_message, status=AgentHealthStatus.AGENT_FAILURE.value)
+        agent_health = self.get_agent_health(
+            component_health=component_health,
+            last_error=error_message,
+            status=AgentHealthStatus.AGENT_FAILURE.value,
+        )
         agent_failure_message.health.CopyFrom(agent_health)
 
         return agent_failure_message
@@ -117,7 +121,11 @@ class OpAMPHTTPClient:
         agent_disconnect = self.get_agent_disconnect()
         first_disconnect_message.agent_disconnect.CopyFrom(agent_disconnect)
 
-        agent_health = self.get_agent_health(component_health=False, last_error=error_message, status=AgentHealthStatus.UNSUPPORTED_RUNTIME_VERSION.value)
+        agent_health = self.get_agent_health(
+            component_health=False,
+            last_error=error_message,
+            status=AgentHealthStatus.UNSUPPORTED_RUNTIME_VERSION.value,
+        )
         first_disconnect_message.health.CopyFrom(agent_health)
 
         self.send_agent_to_server_message(first_disconnect_message)
@@ -128,9 +136,19 @@ class OpAMPHTTPClient:
         for attempt in range(1, max_retries + 1):
             try:
                 # Send first message to OpAMP server, Health is false as the component is not initialized
-                agent_health = self.get_agent_health(component_health=False, last_error="Connecting to Odigos configuration server", status=AgentHealthStatus.STARTING.value)
+                agent_health = self.get_agent_health(
+                    component_health=False,
+                    last_error="Connecting to Odigos configuration server",
+                    status=AgentHealthStatus.STARTING.value,
+                )
                 agent_description = self.get_agent_description()
-                first_message_server_to_agent = self.send_agent_to_server_message(opamp_pb2.AgentToServer(agent_description=agent_description, health=agent_health, remote_config_status=opamp_pb2.RemoteConfigStatus()))
+                first_message_server_to_agent = self.send_agent_to_server_message(
+                    opamp_pb2.AgentToServer(
+                        agent_description=agent_description,
+                        health=agent_health,
+                        remote_config_status=opamp_pb2.RemoteConfigStatus(),
+                    )
+                )
 
                 # Check if the response of the first message is empty
                 # It may happen if OpAMPServer is not available
@@ -180,10 +198,19 @@ class OpAMPHTTPClient:
 
         # If OpAMP server is throttling, it might not respond in the OpAMP client timeout period (5s).
         # In this case, we're trying to send a message to the OpAMP server to indicate that OpAMP is not available.
-        agent_health = self.get_agent_health(component_health=False, last_error="Failed to connect to Odigos configuration server - dynamic configuration unavailable",
-                                             status=AgentHealthStatus.NO_CONNECTION_TO_OPAMP_SERVER.value)
+        agent_health = self.get_agent_health(
+            component_health=False,
+            last_error="Failed to connect to Odigos configuration server - dynamic configuration unavailable",
+            status=AgentHealthStatus.NO_CONNECTION_TO_OPAMP_SERVER.value,
+        )
         agent_description = self.get_agent_description()
-        self.send_agent_to_server_message(opamp_pb2.AgentToServer(agent_description=agent_description, health=agent_health, remote_config_status=opamp_pb2.RemoteConfigStatus()))
+        self.send_agent_to_server_message(
+            opamp_pb2.AgentToServer(
+                agent_description=agent_description,
+                health=agent_health,
+                remote_config_status=opamp_pb2.RemoteConfigStatus(),
+            )
+        )
 
     def worker(self):
         while self.running:
@@ -219,8 +246,7 @@ class OpAMPHTTPClient:
                                     # The default config is preloaded when the EBPFSpanProcessor is initialized
                                     pass
 
-                except requests_odigos.RequestException as e:
-                    # opamp_logger.error(f"Error fetching data: {e}")
+                except requests_odigos.RequestException:
                     pass
                 self.condition.wait(30)
 
@@ -308,8 +334,7 @@ class OpAMPHTTPClient:
         try:
             agent_to_server = opamp_pb2.AgentToServer(remote_config_status=self.remote_config_status)
             return self.send_agent_to_server_message(agent_to_server)
-        except requests_odigos.RequestException as e:
-            # opamp_logger.error(f"Error sending heartbeat to OpAMP server: {e}")
+        except requests_odigos.RequestException:
             pass
 
     def get_agent_description(self) -> opamp_pb2.AgentDescription: # type: ignore
@@ -423,10 +448,20 @@ class OpAMPHTTPClient:
         self.running = False
         # opamp_logger.info("Sending agent disconnect message to OpAMP server...")
         if custom_failure_message:
-            disconnect_message = self.get_agent_failure_disconnect_message(error_message=custom_failure_message, component_health=component_health)
+            disconnect_message = self.get_agent_failure_disconnect_message(
+                error_message=custom_failure_message,
+                component_health=component_health,
+            )
         else:
-            agent_health = self.get_agent_health(component_health=component_health, last_error="Python runtime is exiting", status=AgentHealthStatus.TERMINATED.value)
-            disconnect_message = opamp_pb2.AgentToServer(agent_disconnect=opamp_pb2.AgentDisconnect(), health=agent_health)
+            agent_health = self.get_agent_health(
+                component_health=component_health,
+                last_error="Python runtime is exiting",
+                status=AgentHealthStatus.TERMINATED.value,
+            )
+            disconnect_message = opamp_pb2.AgentToServer(
+                agent_disconnect=opamp_pb2.AgentDisconnect(),
+                health=agent_health,
+            )
 
         with self.condition:
             self.condition.notify_all()

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -166,7 +166,7 @@ class OpAMPHTTPClient:
                             self.opamp_connection_event.error = False
                         return
 
-            except Exception as e:
+            except Exception:
                 pass
 
             if attempt < max_retries:

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -41,7 +41,7 @@ class OpAMPHTTPClient:
     def __init__(self, opamp_connection_event, condition: threading.Condition):
         self.server_host = os.getenv('ODIGOS_OPAMP_SERVER_HOST')
         self.server_url = f"http://{self.server_host}/v1/opamp"
-        self.signals = {}
+        self.container_config = {}
         self.running = True
         self.condition = condition
         self.opamp_connection_event = opamp_connection_event
@@ -166,8 +166,7 @@ class OpAMPHTTPClient:
                                     # The default config is preloaded when the EBPFSpanProcessor is initialized
                                     pass
 
-                        container_config = utils.get_container_config(first_message_server_to_agent.remote_config.config.config_map)
-                        self.signals = utils.parse_first_message_signals(container_config)
+                        self.container_config = utils.get_container_config(first_message_server_to_agent.remote_config.config.config_map)
 
                         # Store initial configs for direct access (TracerProvider doesn't exist yet)
                         remote_config = self.get_remote_config(first_message_server_to_agent)
@@ -184,7 +183,8 @@ class OpAMPHTTPClient:
                             self.opamp_connection_event.error = False
                         return
 
-            except Exception:
+            except Exception as e:
+                print(f"[send_first_message_with_retry] Error: {e}", flush=True)
                 pass
 
             if attempt < max_retries:
@@ -463,13 +463,7 @@ class OpAMPHTTPClient:
         if 'traces' not in remote_config.sample_config or 'headSampling' not in remote_config.sample_config['traces']:
             return None
 
-        head_sampling_config = remote_config.sample_config['traces']['headSampling']
-
-        # Check if we have valid sampling config (same validation as update_agent_config)
-        if head_sampling_config and (head_sampling_config.get('noisyOperations') is not None):
-            return head_sampling_config
-        else:
-            return None
+        return remote_config.sample_config['traces']['headSampling'] or None
 
     def get_initial_sampler_config(self):
         """Get the sampler config from the initial OpAMP message"""
@@ -486,7 +480,7 @@ class OpAMPHTTPClient:
 class MockOpAMPClient:
     def __init__(self, opamp_connection_event, *args, **kwargs):
         self.pid = os.getpid()
-        self.signals = {'traceSignal': True}
+        self.container_config = {"traces": {}}
         self.sampler = None  # For compatibility
         opamp_connection_event.event.set()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.81"
+version = "1.0.82"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,9 @@ extend-exclude = [
 # Default rule set: pycodestyle errors (E) + pyflakes (F).
 select = ["E", "F"]
 
+[tool.ruff.lint.per-file-ignores]
+"initializer/components.py" = ["E402"]
+
 [tool.ruff.format]
 quote-style = "preserve"
 indent-style = "space"

--- a/tests/unit/test_odigos_sampler.py
+++ b/tests/unit/test_odigos_sampler.py
@@ -158,7 +158,7 @@ class TestShouldSample:
             attributes={},
         )
 
-        assert result.decision == Decision.RECORD_ONLY
+        assert result.decision == Decision.DROP
         assert result.trace_state is not None
         assert result.trace_state.get("odigos") == "c:n;dr.p:0;dr.id:drop-everything"
 
@@ -302,7 +302,7 @@ class TestDryRun:
             attributes={},
         )
 
-        assert result.decision == Decision.RECORD_ONLY
+        assert result.decision == Decision.DROP
         assert result.trace_state is not None
         odigos_value = result.trace_state.get("odigos")
         assert odigos_value is not None
@@ -310,7 +310,7 @@ class TestDryRun:
 
     def test_dry_run_omitted_defaults_to_disabled(self, sampler):
         # When the OpAMP push omits `dryRun` (older servers), treat as disabled:
-        # must still record (not sample) and must NOT add a `;dry:*` suffix.
+        # must still drop and must NOT add a `;dry:*` suffix.
         sampler.update_config(
             {
                 "noisyOperations": [
@@ -327,7 +327,113 @@ class TestDryRun:
             attributes={},
         )
 
-        assert result.decision == Decision.RECORD_ONLY
+        assert result.decision == Decision.DROP
         odigos_value = result.trace_state.get("odigos")
         assert odigos_value is not None
         assert ";dry:" not in odigos_value
+
+
+class TestRecordMode:
+    """Tests for record_mode controlling the not-sampled decision."""
+
+    def test_all_spans_mode_uses_record_only_for_noisy_drop(self):
+        s = OdigosSampler()
+        s.update_config(
+            {
+                "spanMetricsMode": "all-spans",
+                "noisyOperations": [
+                    {"id": "drop-everything", "percentageAtMost": 0},
+                ],
+            }
+        )
+
+        result = s.should_sample(
+            parent_context=None,
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            name="GET /anything",
+            kind=SpanKind.SERVER,
+            attributes={},
+        )
+
+        assert result.decision == Decision.RECORD_ONLY
+
+    def test_default_mode_uses_drop_for_noisy_drop(self):
+        s = OdigosSampler()
+        s.update_config(
+            {
+                "noisyOperations": [
+                    {"id": "drop-everything", "percentageAtMost": 0},
+                ],
+            }
+        )
+
+        result = s.should_sample(
+            parent_context=None,
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            name="GET /anything",
+            kind=SpanKind.SERVER,
+            attributes={},
+        )
+
+        assert result.decision == Decision.DROP
+
+    def test_parent_not_sampled_drops_by_default(self):
+        s = OdigosSampler()
+        span_context = SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(0),
+        )
+        parent_context = set_span_in_context(NonRecordingSpan(span_context))
+
+        result = s.should_sample(
+            parent_context=parent_context,
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            name="GET /anything",
+            kind=SpanKind.SERVER,
+            attributes={},
+        )
+
+        assert result.decision == Decision.DROP
+
+    def test_parent_not_sampled_records_with_all_spans_mode(self):
+        s = OdigosSampler()
+        s.update_config({"spanMetricsMode": "all-spans"})
+        span_context = SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(0),
+        )
+        parent_context = set_span_in_context(NonRecordingSpan(span_context))
+
+        result = s.should_sample(
+            parent_context=parent_context,
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            name="GET /anything",
+            kind=SpanKind.SERVER,
+            attributes={},
+        )
+
+        assert result.decision == Decision.RECORD_ONLY
+
+    def test_parent_sampled_always_records_and_samples(self):
+        s = OdigosSampler()
+        span_context = SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        parent_context = set_span_in_context(NonRecordingSpan(span_context))
+
+        result = s.should_sample(
+            parent_context=parent_context,
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            name="GET /anything",
+            kind=SpanKind.SERVER,
+            attributes={},
+        )
+
+        assert result.decision == Decision.RECORD_AND_SAMPLE

--- a/tests/unit/test_odigos_sampler.py
+++ b/tests/unit/test_odigos_sampler.py
@@ -158,7 +158,7 @@ class TestShouldSample:
             attributes={},
         )
 
-        assert result.decision == Decision.DROP
+        assert result.decision == Decision.RECORD_ONLY
         assert result.trace_state is not None
         assert result.trace_state.get("odigos") == "c:n;dr.p:0;dr.id:drop-everything"
 
@@ -302,7 +302,7 @@ class TestDryRun:
             attributes={},
         )
 
-        assert result.decision == Decision.DROP
+        assert result.decision == Decision.RECORD_ONLY
         assert result.trace_state is not None
         odigos_value = result.trace_state.get("odigos")
         assert odigos_value is not None
@@ -310,7 +310,7 @@ class TestDryRun:
 
     def test_dry_run_omitted_defaults_to_disabled(self, sampler):
         # When the OpAMP push omits `dryRun` (older servers), treat as disabled:
-        # must still drop and must NOT add a `;dry:*` suffix.
+        # must still record (not sample) and must NOT add a `;dry:*` suffix.
         sampler.update_config(
             {
                 "noisyOperations": [
@@ -327,7 +327,7 @@ class TestDryRun:
             attributes={},
         )
 
-        assert result.decision == Decision.DROP
+        assert result.decision == Decision.RECORD_ONLY
         odigos_value = result.trace_state.get("odigos")
         assert odigos_value is not None
         assert ";dry:" not in odigos_value

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.81"
+version = "1.0.82"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1416,7 +1416,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.81"
+version = "1.0.82"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Add support for span metrics "all-spans" mode in Python.
When spanMetricsMode is set to all-spans, the agent always records and exports traces regardless of the sampling decision. This ensures that unsampled spans are not dropped at the agent level but are instead forwarded to the collector, while the head sampling decision is still computed in the agent.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
