### PR TITLE
fix: extract codeAttributes from container_config.traces

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.82"
+version = "1.0.83"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.82",
+    "odigos-opentelemetry-python == 1.0.83",
 ]
 
 [tool.uv.sources]

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -267,12 +267,11 @@ def update_agent_config(conf: Config):
     if provider is None:
         return
 
-    # Update sampler configuration if sample_config is present
-    if hasattr(conf, 'sample_config') and conf.sample_config:
-        # Extract headSampling configuration from traces.headSampling
+    # Update sampler configuration if container_config is present
+    if hasattr(conf, 'container_config') and conf.container_config:
         head_sampling_config = None
-        if 'traces' in conf.sample_config and 'headSampling' in conf.sample_config['traces']:
-            head_sampling_config = conf.sample_config['traces']['headSampling']
+        if 'traces' in conf.container_config and 'headSampling' in conf.container_config['traces']:
+            head_sampling_config = conf.container_config['traces']['headSampling']
 
         # Apply config to sampler - sampler will always exist when this callback is called
         # because update_agent_config is only called from OpAMP worker thread after sampler creation

--- a/opamp/config.py
+++ b/opamp/config.py
@@ -27,7 +27,7 @@ class CodeAttributes(DefaultNoneMixin):
 @dataclass
 class Config(DefaultNoneMixin):
     code_attributes: CodeAttributes = field(default_factory=CodeAttributes)
-    sample_config: Dict[str, Any] = field(default_factory=dict)
+    container_config: Dict[str, Any] = field(default_factory=dict)
     span_metrics_mode: Optional[str] = None
 
 

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -23,7 +23,7 @@ from initializer.process_resource import PROCESS_VPID
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import DecodeError
 
-from opamp.config import from_dict, Config
+from opamp.config import from_dict, Config, CodeAttributes
 
 # Setup the logger
 opamp_logger = logging.getLogger('odigos')
@@ -183,8 +183,7 @@ class OpAMPHTTPClient:
                             self.opamp_connection_event.error = False
                         return
 
-            except Exception as e:
-                print(f"[send_first_message_with_retry] Error: {e}", flush=True)
+            except Exception:
                 pass
 
             if attempt < max_retries:
@@ -311,12 +310,19 @@ class OpAMPHTTPClient:
             config = from_dict(Config, inner)
 
         # Extract container_config if present
-        sample_config = decoded_map.get("container_config", None)
-        if sample_config is not None:
-            config.sample_config = sample_config
+        container_config = decoded_map.get("container_config", None)
+        if container_config is not None:
+            config.container_config = container_config
 
             try:
-                config.span_metrics_mode = sample_config['traces']['headSampling']['spanMetricsMode']
+                config.span_metrics_mode = container_config['traces']['headSampling']['spanMetricsMode']
+            except (KeyError, TypeError):
+                pass
+
+            try:
+                code_attrs_raw = container_config['traces']['codeAttributes']
+                if isinstance(code_attrs_raw, dict):
+                    config.code_attributes = from_dict(CodeAttributes, code_attrs_raw)
             except (KeyError, TypeError):
                 pass
 
@@ -456,14 +462,14 @@ class OpAMPHTTPClient:
 
     def _extract_sampler_config(self, remote_config):
         """Extract sampler config from remote config, same logic as update_agent_config"""
-        if not hasattr(remote_config, 'sample_config') or not remote_config.sample_config:
+        if not hasattr(remote_config, 'container_config') or not remote_config.container_config:
             return None
 
         # Extract headSampling configuration from traces.headSampling
-        if 'traces' not in remote_config.sample_config or 'headSampling' not in remote_config.sample_config['traces']:
+        if 'traces' not in remote_config.container_config or 'headSampling' not in remote_config.container_config['traces']:
             return None
 
-        return remote_config.sample_config['traces']['headSampling'] or None
+        return remote_config.container_config['traces']['headSampling'] or None
 
     def get_initial_sampler_config(self):
         """Get the sampler config from the initial OpAMP message"""

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -303,11 +303,7 @@ class OpAMPHTTPClient:
                 # If not JSON, just keep it as raw bytes
                 decoded_map[key] = body_bytes
 
-        inner = decoded_map.get("", None)
-        if inner is None:
-            config = Config()  # Return default values for config
-        else:
-            config = from_dict(Config, inner)
+        config = Config()
 
         # Extract container_config if present
         container_config = decoded_map.get("container_config", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.82"
+version = "1.0.83"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.82"
+version = "1.0.83"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1416,7 +1416,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.82"
+version = "1.0.83"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

The server sends codeAttributes inside the container_config config map entry at traces.codeAttributes, but get_remote_config only looked for it under the empty-string config_map key which the server never sends. This caused code attributes to always default to False.

Also renames the misleading sample_config field/variable to container_config since it holds the full container configuration, not just sampling config.


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1693
