### PR TITLE
CORE-1017: support old semconv for http client in sampling

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.83"
+version = "1.0.84"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.83",
+    "odigos-opentelemetry-python == 1.0.84",
 ]
 
 [tool.uv.sources]

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -133,7 +133,9 @@ class OdigosSampler(Sampler):
             # sampler_logger.debug('No noisy operation matched, sampling the trace')
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=_get_parent_trace_state(parent_context))
 
-    def _match_http_server_sample_rule(self, http_server_rule: HeadSamplingHttpServerOperationMatcher, span_attributes: Mapping[str, AttributeValue]) -> bool:
+    def _match_http_server_sample_rule(
+        self, http_server_rule: HeadSamplingHttpServerOperationMatcher, span_attributes: Mapping[str, AttributeValue]
+    ) -> bool:
         """
         Try to match all the http server's attributes to the definitions of the noisy action
         """
@@ -173,7 +175,7 @@ class OdigosSampler(Sampler):
         server_address = get_attribute(span_attributes, server_attributes_semconv.SERVER_ADDRESS, "net.peer.name", "http.host")
         if server_address:
             server_address = strip_port(server_address)
-        
+
         # Old semconv for url is a target that we need to get the client_path from → new semconv: "url.template"/"url.path"
         client_path = get_attribute(span_attributes, "url.template", url_attributes_semconv.URL_PATH)
         if not client_path:

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -1,14 +1,17 @@
 import logging
 from threading import Lock
-from typing import Any, Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence
+from urllib.parse import urlsplit
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult, _get_parent_trace_state
 from opentelemetry.semconv.attributes import http_attributes as http_attributes_semconv
 from opentelemetry.semconv.attributes import server_attributes as server_attributes_semconv
+from opentelemetry.semconv.attributes import url_attributes as url_attributes_semconv
 from opentelemetry.trace import Link, SpanKind, TraceState, get_current_span
-from opentelemetry.util.types import Attributes
+from opentelemetry.util.types import Attributes, AttributeValue
 
+from initializer.odigos_sampler_helpers import get_attribute, strip_port
 from initializer.schemas.sampling import (
     HeadSamplingConfig,
     HeadSamplingHttpClientOperationMatcher,
@@ -130,25 +133,17 @@ class OdigosSampler(Sampler):
             # sampler_logger.debug('No noisy operation matched, sampling the trace')
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes=attributes, trace_state=_get_parent_trace_state(parent_context))
 
-    @staticmethod
-    def _get_attribute(span_attributes: Mapping[str, Any], *keys: str):
-        """Return the first non-None value found for the given attribute keys."""
-        for key in keys:
-            value = span_attributes.get(key)
-            if value is not None:
-                return value
-        return None
-
-    def _match_http_server_sample_rule(self, http_server_rule: HeadSamplingHttpServerOperationMatcher, span_attributes: Mapping[str, Any]) -> bool:
+    def _match_http_server_sample_rule(self, http_server_rule: HeadSamplingHttpServerOperationMatcher, span_attributes: Mapping[str, AttributeValue]) -> bool:
         """
         Try to match all the http server's attributes to the definitions of the noisy action
         """
-        span_route = span_attributes.get(http_attributes_semconv.HTTP_ROUTE)
+        raw_route = span_attributes.get(http_attributes_semconv.HTTP_ROUTE)
+        span_route: Optional[str] = raw_route if isinstance(raw_route, str) else None
         # Old semconv: "http.method" → new semconv: "http.request.method"
-        span_method = self._get_attribute(span_attributes, http_attributes_semconv.HTTP_REQUEST_METHOD, "http.method")
+        span_method = get_attribute(span_attributes, http_attributes_semconv.HTTP_REQUEST_METHOD, "http.method")
 
         # Some instrumentations send target instead of route
-        target = self._get_attribute(span_attributes, "http.target", "url.path")
+        target = get_attribute(span_attributes, "http.target", "url.path")
 
         if http_server_rule.get("route") and http_server_rule["route"] != span_route:
             # If we have route in the span attributes, evaluate it first (use template matching
@@ -166,46 +161,67 @@ class OdigosSampler(Sampler):
 
         return True
 
-    def _match_http_client_sample_rule(self, http_client_rule: HeadSamplingHttpClientOperationMatcher, span_attributes: Mapping[str, Any]) -> bool:
+    def _match_http_client_sample_rule(
+        self,
+        http_client_rule: HeadSamplingHttpClientOperationMatcher,
+        span_attributes: Mapping[str, AttributeValue],
+    ) -> bool:
         """
         Try to match all the http client's attributes to the definitions of the noisy action
         """
-        # Old semconv: "net.peer.name" / "http.host" → new semconv: "server.address"
-        server_address = self._get_attribute(span_attributes, server_attributes_semconv.SERVER_ADDRESS, "net.peer.name", "http.host")
-        url_template = span_attributes.get("url.template")
+        # Old semconv: "http.host"/"net.peer.name" → new semconv: "server.address"
+        server_address = get_attribute(span_attributes, server_attributes_semconv.SERVER_ADDRESS, "net.peer.name", "http.host")
+        if server_address:
+            server_address = strip_port(server_address)
+        
+        # Old semconv for url is a target that we need to get the client_path from → new semconv: "url.template"/"url.path"
+        client_path = get_attribute(span_attributes, "url.template", url_attributes_semconv.URL_PATH)
+        if not client_path:
+            # Old semconv: "http.target" is a path (may carry a query); "http.url"/"url.full" is a full URL we parse the path out of.
+            target = get_attribute(span_attributes, "http.target", "url.full", "http.url")
+            client_path = urlsplit(target).path if target else None
+
         # Old semconv: "http.method" → new semconv: "http.request.method"
-        method = self._get_attribute(span_attributes, http_attributes_semconv.HTTP_REQUEST_METHOD, "http.method")
+        method = get_attribute(span_attributes, http_attributes_semconv.HTTP_REQUEST_METHOD, "http.method")
 
         if http_client_rule.get("serverAddress") and http_client_rule["serverAddress"] != server_address:
             return False
-        if http_client_rule.get("templatedPath") and http_client_rule["templatedPath"] != url_template:
+        templated_path = http_client_rule.get("templatedPath")
+        if templated_path and not self._match_rule_route_to_span(templated_path, client_path or ""):
             return False
-        if http_client_rule.get("templatedPathPrefix") and not (url_template or "").startswith(http_client_rule["templatedPathPrefix"]):
+        templated_path_prefix = http_client_rule.get("templatedPathPrefix")
+        if templated_path_prefix and not self._match_rule_route_to_span(templated_path_prefix, client_path or "", route_has_prefix=True):
             return False
         if http_client_rule.get("method") and http_client_rule["method"] != method:
             return False
 
         return True
 
-    def _match_rule_route_to_span(self, rule_route: str, span_value: str) -> bool:
+    def _match_rule_route_to_span(self, rule_route: str, span_value: str, route_has_prefix: bool = False) -> bool:
         """
         Match a sampling rule route (e.g. /item/{id}) against a span value, which can be either
         a templated route (e.g. /item/{item_id}) or a full URL target (e.g. /item/123?param=hello).
-        Path param segments ({...}) in the rule are treated as wildcards.
+        Wildcard segments ({...}, :name, *) in the rule match any single span segment.
+        With prefix=True the span may have extra trailing segments (prefix match).
         """
         span_value = span_value.split('?')[0]
         rule_parts = [part for part in rule_route.split('/') if part]
         span_parts = [part for part in span_value.split('/') if part]
 
-        if len(rule_parts) != len(span_parts):
-            return False
+        if route_has_prefix:
+            # Prefix match: span may have extra trailing segments, but not fewer.
+            if len(span_parts) < len(rule_parts):
+                return False
+        else:
+            # Exact match: segment counts must be identical.
+            if len(span_parts) != len(rule_parts):
+                return False
 
-        # Traverse both rule and span segments
-        for i in range(len(rule_parts)):
-            # If we hit a path param in the rule, it matches any span segment
-            if rule_parts[i].startswith('{'):
+        for rule_segment, span_segment in zip(rule_parts, span_parts):
+            # Wildcard segment ({text}, :name, *) matches any single span segment
+            if rule_segment == '*' or (rule_segment.startswith('{') and rule_segment.endswith('}')) or rule_segment.startswith(':'):
                 continue
-            if rule_parts[i] != span_parts[i]:
+            if rule_segment != span_segment:
                 return False
 
         return True

--- a/initializer/odigos_sampler_helpers.py
+++ b/initializer/odigos_sampler_helpers.py
@@ -1,0 +1,25 @@
+from typing import Mapping, Optional
+
+from opentelemetry.util.types import AttributeValue
+
+
+def strip_port(host: str) -> str:
+    """Remove a trailing :port from a host, leaving bare IPv6 literals untouched."""
+    if host.startswith('['):  # bracketed IPv6, optionally followed by :port — "[::1]:8080"
+        return host[1:].split(']')[0]
+    if host.count(':') == 1:  # "host:port" (hostname or IPv4); bare IPv6 has multiple colons
+        return host.split(':')[0]
+    return host
+
+
+def get_attribute(span_attributes: Mapping[str, AttributeValue], *keys: str) -> Optional[str]:
+        """Return the first string value found for the given attribute keys.
+
+        Span attribute values can be str/bool/int/float or sequences of those; the HTTP
+        semconv keys we look up are always strings, so non-str values are ignored.
+        """
+        for key in keys:
+            value = span_attributes.get(key)
+            if isinstance(value, str):
+                return value
+        return None

--- a/initializer/odigos_sampler_helpers.py
+++ b/initializer/odigos_sampler_helpers.py
@@ -13,13 +13,13 @@ def strip_port(host: str) -> str:
 
 
 def get_attribute(span_attributes: Mapping[str, AttributeValue], *keys: str) -> Optional[str]:
-        """Return the first string value found for the given attribute keys.
+    """Return the first string value found for the given attribute keys.
 
-        Span attribute values can be str/bool/int/float or sequences of those; the HTTP
-        semconv keys we look up are always strings, so non-str values are ignored.
-        """
-        for key in keys:
-            value = span_attributes.get(key)
-            if isinstance(value, str):
-                return value
-        return None
+    Span attribute values can be str/bool/int/float or sequences of those; the HTTP
+    semconv keys we look up are always strings, so non-str values are ignored.
+    """
+    for key in keys:
+        value = span_attributes.get(key)
+        if isinstance(value, str):
+            return value
+    return None

--- a/initializer/odigos_sampler_helpers.py
+++ b/initializer/odigos_sampler_helpers.py
@@ -1,15 +1,12 @@
 from typing import Mapping, Optional
+from urllib.parse import urlsplit
 
 from opentelemetry.util.types import AttributeValue
 
 
 def strip_port(host: str) -> str:
-    """Remove a trailing :port from a host, leaving bare IPv6 literals untouched."""
-    if host.startswith('['):  # bracketed IPv6, optionally followed by :port — "[::1]:8080"
-        return host[1:].split(']')[0]
-    if host.count(':') == 1:  # "host:port" (hostname or IPv4); bare IPv6 has multiple colons
-        return host.split(':')[0]
-    return host
+    parsed = urlsplit(f'//{host}')
+    return parsed.hostname or host
 
 
 def get_attribute(span_attributes: Mapping[str, AttributeValue], *keys: str) -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.83"
+version = "1.0.84"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/tests/unit/test_odigos_sampler.py
+++ b/tests/unit/test_odigos_sampler.py
@@ -437,3 +437,92 @@ class TestRecordMode:
         )
 
         assert result.decision == Decision.RECORD_AND_SAMPLE
+
+
+class TestHttpClientSemconv:
+    """_match_http_client_sample_rule must work across old and new HTTP semconv.
+
+    New semconv: server.address, url.template, url.path, http.request.method.
+    Old semconv: net.peer.name / http.host (host[:port]), http.target (path?query),
+                 http.url / url.full (full URL), http.method.
+    """
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            pytest.param({"server.address": "payments"}, id="new-server.address"),
+            pytest.param({"net.peer.name": "payments"}, id="old-net.peer.name"),
+            pytest.param({"http.host": "payments"}, id="old-http.host-no-port"),
+            pytest.param({"http.host": "payments:8080"}, id="old-http.host-with-port"),
+        ],
+    )
+    def test_server_address_matches_across_semconv(self, sampler, attributes):
+        rule = {"serverAddress": "payments"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is True
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            pytest.param({"server.address": "other"}, id="new-mismatch"),
+            pytest.param({"http.host": "other:8080"}, id="old-mismatch-with-port"),
+            pytest.param({}, id="absent"),
+        ],
+    )
+    def test_server_address_mismatch_across_semconv(self, sampler, attributes):
+        rule = {"serverAddress": "payments"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is False
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            pytest.param({"url.template": "/item/{id}"}, id="new-url.template"),
+            pytest.param({"url.path": "/item/123"}, id="new-url.path-concrete"),
+            pytest.param({"http.target": "/item/123?q=hello"}, id="old-http.target-with-query"),
+            pytest.param({"http.url": "http://h:8080/item/123?q=1"}, id="old-http.url-full"),
+            pytest.param({"url.full": "https://h/item/abc"}, id="new-url.full"),
+        ],
+    )
+    def test_templated_path_matches_across_semconv(self, sampler, attributes):
+        rule = {"templatedPath": "/item/{id}"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is True
+
+    def test_new_semconv_preferred_over_old_in_http_dup_mode(self, sampler):
+        # http/dup emits both. url.template (new) must win over http.target (old):
+        # the templated path disagrees with the rule, so the rule must NOT match
+        # even though the concrete old-semconv path would have.
+        rule = {"templatedPath": "/item/{id}"}
+        attributes = {"url.template": "/wrong/{id}", "http.target": "/item/123"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is False
+
+    @pytest.mark.parametrize(
+        "attributes, expected",
+        [
+            pytest.param({"url.path": "/api/v1/users"}, True, id="new-prefix-hit"),
+            pytest.param({"http.target": "/api/v1/users?x=1"}, True, id="old-prefix-hit"),
+            pytest.param({"http.url": "http://h/api/v2/users"}, False, id="old-prefix-miss"),
+        ],
+    )
+    def test_templated_path_prefix_across_semconv(self, sampler, attributes, expected):
+        rule = {"templatedPathPrefix": "/api/v1"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is expected
+
+    def test_templated_path_prefix_with_wildcard_segment(self, sampler):
+        rule = {"templatedPathPrefix": "/a/*/items"}
+        assert sampler._match_http_client_sample_rule(rule, {"url.path": "/a/9/items/extra"}) is True
+        assert sampler._match_http_client_sample_rule(rule, {"url.path": "/a/9/orders"}) is False
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            pytest.param({"url.path": "/p", "http.request.method": "GET"}, id="new-http.request.method"),
+            pytest.param({"url.path": "/p", "http.method": "GET"}, id="old-http.method"),
+        ],
+    )
+    def test_method_matches_across_semconv(self, sampler, attributes):
+        rule = {"templatedPath": "/p", "method": "GET"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is True
+
+    def test_method_mismatch_across_semconv(self, sampler):
+        rule = {"templatedPath": "/p", "method": "GET"}
+        assert sampler._match_http_client_sample_rule(rule, {"url.path": "/p", "http.method": "POST"}) is False
+

--- a/tests/unit/test_odigos_sampler.py
+++ b/tests/unit/test_odigos_sampler.py
@@ -525,4 +525,3 @@ class TestHttpClientSemconv:
     def test_method_mismatch_across_semconv(self, sampler):
         rule = {"templatedPath": "/p", "method": "GET"}
         assert sampler._match_http_client_sample_rule(rule, {"url.path": "/p", "http.method": "POST"}) is False
-

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.83"
+version = "1.0.84"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1416,7 +1416,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.83"
+version = "1.0.84"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
We didn't catch old semconvs for http client in sampling, leading to that that we didn't get tracestates on servers whose http client still worked on the old semconvs.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
