### PR TITLE
CORE-1054 | Support python agent over unix

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.85"
+version = "1.0.86"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.85",
+    "odigos-opentelemetry-python == 1.0.86",
 ]
 
 [tool.uv.sources]

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -6,6 +6,7 @@ import base64
 import threading
 import requests_odigos
 import logging
+from typing import Optional
 
 from uuid_extensions import uuid7
 from opentelemetry.semconv.resource import ResourceAttributes
@@ -56,7 +57,7 @@ class OpAMPHTTPClient:
     def __repr__(self):
         return f"<OpAMPHTTPClient instance_uid={self.instance_uid} pid={self.pid}>"
 
-    def start(self, python_version_supported: bool = None):
+    def start(self, python_version_supported: bool = False):
         if not python_version_supported:
             python_version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
             error_message = f"Opentelemetry SDK require Python in version 3.8 or higher [{python_version} is not supported]"
@@ -409,7 +410,7 @@ class OpAMPHTTPClient:
         # transport.from_env() returns None when neither is configured.
         return self._transport is not None
 
-    def shutdown(self, custom_failure_message: str = None, component_health: bool = False):
+    def shutdown(self, custom_failure_message: Optional[str] = None, component_health: bool = False):
         self.running = False
         # opamp_logger.info("Sending agent disconnect message to OpAMP server...")
         if custom_failure_message:

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -16,7 +16,7 @@ from opentelemetry.context import (
     set_value,
 )
 
-from opamp import opamp_pb2, anyvalue_pb2, utils
+from opamp import opamp_pb2, anyvalue_pb2, transport, utils
 from opamp.health_status import AgentHealthStatus
 from initializer.process_resource import PROCESS_VPID
 
@@ -39,8 +39,7 @@ env_var_mappings = {
 
 class OpAMPHTTPClient:
     def __init__(self, opamp_connection_event, condition: threading.Condition):
-        self.server_host = os.getenv('ODIGOS_OPAMP_SERVER_HOST')
-        self.server_url = f"http://{self.server_host}/v1/opamp"
+        self._transport = transport.from_env()
         self.container_config = {}
         self.running = True
         self.condition = condition
@@ -263,7 +262,7 @@ class OpAMPHTTPClient:
 
         self.send_agent_to_server_message(opamp_pb2.AgentToServer(health=health_msg))
 
-    def get_remote_config(self, message) -> dict:
+    def get_remote_config(self, message) -> Config:
         """
         Given a Protobuf message with a 'remote_config' field,
         decode all bytes and base64-encoded subfields into a clean Python dict.
@@ -392,8 +391,7 @@ class OpAMPHTTPClient:
 
         try:
             agent_message = attach(set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True))
-            response = requests_odigos.post(self.server_url, data=message_bytes, headers=headers, timeout=5)
-            response.raise_for_status()
+            response_bytes = self._transport.post(message_bytes, headers, timeout=5)
         except Exception:
             return opamp_pb2.ServerToAgent()
         finally:
@@ -401,22 +399,15 @@ class OpAMPHTTPClient:
 
         server_to_agent = opamp_pb2.ServerToAgent()
         try:
-            server_to_agent.ParseFromString(response.content)
+            server_to_agent.ParseFromString(response_bytes)
         except (DecodeError, NotImplementedError):
             return opamp_pb2.ServerToAgent()
         return server_to_agent
 
     def mandatory_env_vars_set(self):
-        mandatory_env_vars = {
-            "ODIGOS_OPAMP_SERVER_HOST": self.server_host,
-        }
-
-        for env_var, value in mandatory_env_vars.items():
-            if not value:
-                # opamp_logger.error(f"{env_var} environment variable not set")
-                return False
-
-        return True
+        # Either ODIGOS_OPAMP_UNIX_SOCKET or ODIGOS_OPAMP_SERVER_HOST must be set;
+        # transport.from_env() returns None when neither is configured.
+        return self._transport is not None
 
     def shutdown(self, custom_failure_message: str = None, component_health: bool = False):
         self.running = False

--- a/opamp/transport.py
+++ b/opamp/transport.py
@@ -1,0 +1,64 @@
+import os
+import socket
+import http.client
+
+import requests_odigos
+
+
+class TCPTransport:
+    """HTTP/1.1 over TCP. Talks to ODIGOS_OPAMP_SERVER_HOST."""
+
+    def __init__(self, host: str):
+        self._url = f"http://{host}/v1/opamp"
+
+    def post(self, body: bytes, headers: dict, timeout: float) -> bytes:
+        response = requests_odigos.post(self._url, data=body, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        return response.content
+
+
+class UnixTransport:
+    """HTTP/1.1 over an AF_UNIX stream socket. Talks to ODIGOS_OPAMP_UNIX_SOCKET."""
+
+    def __init__(self, socket_path: str):
+        self._socket_path = socket_path
+
+    def post(self, body: bytes, headers: dict, timeout: float) -> bytes:
+        conn = _UnixHTTPConnection(self._socket_path, timeout=timeout)
+        try:
+            conn.request("POST", "/v1/opamp", body=body, headers=headers)
+            response = conn.getresponse()
+            if response.status >= 400:
+                raise RuntimeError(f"opamp unix POST returned status {response.status}")
+            return response.read()
+        finally:
+            conn.close()
+
+
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """http.client.HTTPConnection that talks over a unix domain socket."""
+
+    def __init__(self, socket_path: str, timeout: float):
+        super().__init__("localhost", timeout=timeout)
+        self._socket_path = socket_path
+
+    def connect(self):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        sock.connect(self._socket_path)
+        self.sock = sock
+
+
+def from_env():
+    """Pick an OpAMP transport from env vars. ODIGOS_OPAMP_UNIX_SOCKET wins if both are set.
+    Returns None if neither is set so the client can fail fast on missing config.
+    """
+    socket_path = os.getenv("ODIGOS_OPAMP_UNIX_SOCKET")
+    if socket_path:
+        return UnixTransport(socket_path)
+
+    host = os.getenv("ODIGOS_OPAMP_SERVER_HOST")
+    if host:
+        return TCPTransport(host)
+
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.85"
+version = "1.0.86"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/tests/opamp/test_http_client.py
+++ b/tests/opamp/test_http_client.py
@@ -1,6 +1,6 @@
 import pytest
 import threading
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 from opamp.http_client import OpAMPHTTPClient
 from opamp import opamp_pb2
@@ -35,7 +35,7 @@ class TestSendAgentToServerMessage:
     def test_successful_response(self, test_client):
         expected_response = opamp_pb2.ServerToAgent()
         expected_response.instance_uid = b"test-uid"
-        
+
         mock_response = Mock()
         mock_response.content = expected_response.SerializeToString()
         mock_response.raise_for_status = Mock()
@@ -43,62 +43,62 @@ class TestSendAgentToServerMessage:
         with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert result.instance_uid == b"test-uid"
 
     def test_timeout_returns_empty_response(self, test_client):
         import requests_odigos
-        
+
         with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("Connection timed out")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
     def test_connection_error_returns_empty_response(self, test_client):
         import requests_odigos
-        
+
         with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.ConnectionError("Connection refused")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
     def test_http_error_403_returns_empty_response(self, test_client):
         import requests_odigos
-        
+
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("403 Forbidden")
-        
+
         with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
     def test_http_error_500_returns_empty_response(self, test_client):
         import requests_odigos
-        
+
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("500 Internal Server Error")
-        
+
         with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
     def test_request_exception_returns_empty_response(self, test_client):
         import requests_odigos
-        
+
         with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.RequestException("Some request error")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
@@ -106,7 +106,7 @@ class TestSendAgentToServerMessage:
         with patch('opamp.transport.requests_odigos.post', side_effect=RuntimeError("Unexpected error")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
@@ -118,24 +118,24 @@ class TestSendAgentToServerMessage:
         with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
-            
+
             assert isinstance(result, opamp_pb2.ServerToAgent)
 
     def test_sequence_num_increments_on_each_call(self, test_client):
         import requests_odigos
-        
+
         initial_seq = test_client.next_sequence_num
-        
+
         with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("timeout")):
             test_client.send_agent_to_server_message(opamp_pb2.AgentToServer())
             assert test_client.next_sequence_num == initial_seq + 1
-            
+
             test_client.send_agent_to_server_message(opamp_pb2.AgentToServer())
             assert test_client.next_sequence_num == initial_seq + 2
 
     def test_does_not_crash_app_on_any_exception(self, test_client):
         import requests_odigos
-        
+
         exceptions_to_test = [
             requests_odigos.Timeout("timeout"),
             requests_odigos.ConnectionError("connection error"),
@@ -145,7 +145,7 @@ class TestSendAgentToServerMessage:
             ValueError("value error"),
             Exception("generic exception"),
         ]
-        
+
         for exc in exceptions_to_test:
             with patch('opamp.transport.requests_odigos.post', side_effect=exc):
                 message = opamp_pb2.AgentToServer()

--- a/tests/opamp/test_http_client.py
+++ b/tests/opamp/test_http_client.py
@@ -8,6 +8,7 @@ from opamp import opamp_pb2
 
 class MockConnectionEvent:
     """Mock for the opamp_connection_event."""
+
     def __init__(self):
         self.event = threading.Event()
         self.error = False
@@ -31,7 +32,6 @@ def test_client(mock_connection_event, mock_condition):
 
 
 class TestSendAgentToServerMessage:
-
     def test_successful_response(self, test_client):
         expected_response = opamp_pb2.ServerToAgent()
         expected_response.instance_uid = b"test-uid"

--- a/tests/opamp/test_http_client.py
+++ b/tests/opamp/test_http_client.py
@@ -40,7 +40,7 @@ class TestSendAgentToServerMessage:
         mock_response.content = expected_response.SerializeToString()
         mock_response.raise_for_status = Mock()
 
-        with patch('opamp.http_client.requests_odigos.post', return_value=mock_response):
+        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -49,7 +49,7 @@ class TestSendAgentToServerMessage:
     def test_timeout_returns_empty_response(self, test_client):
         import requests_odigos
         
-        with patch('opamp.http_client.requests_odigos.post', side_effect=requests_odigos.Timeout("Connection timed out")):
+        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("Connection timed out")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -59,7 +59,7 @@ class TestSendAgentToServerMessage:
     def test_connection_error_returns_empty_response(self, test_client):
         import requests_odigos
         
-        with patch('opamp.http_client.requests_odigos.post', side_effect=requests_odigos.ConnectionError("Connection refused")):
+        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.ConnectionError("Connection refused")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -72,7 +72,7 @@ class TestSendAgentToServerMessage:
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("403 Forbidden")
         
-        with patch('opamp.http_client.requests_odigos.post', return_value=mock_response):
+        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -85,7 +85,7 @@ class TestSendAgentToServerMessage:
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("500 Internal Server Error")
         
-        with patch('opamp.http_client.requests_odigos.post', return_value=mock_response):
+        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -95,7 +95,7 @@ class TestSendAgentToServerMessage:
     def test_request_exception_returns_empty_response(self, test_client):
         import requests_odigos
         
-        with patch('opamp.http_client.requests_odigos.post', side_effect=requests_odigos.RequestException("Some request error")):
+        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.RequestException("Some request error")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -103,7 +103,7 @@ class TestSendAgentToServerMessage:
             assert not result.ListFields()
 
     def test_unknown_exception_returns_empty_response(self, test_client):
-        with patch('opamp.http_client.requests_odigos.post', side_effect=RuntimeError("Unexpected error")):
+        with patch('opamp.transport.requests_odigos.post', side_effect=RuntimeError("Unexpected error")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -115,7 +115,7 @@ class TestSendAgentToServerMessage:
         mock_response.content = b"invalid protobuf data"
         mock_response.raise_for_status = Mock()
 
-        with patch('opamp.http_client.requests_odigos.post', return_value=mock_response):
+        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
             
@@ -126,7 +126,7 @@ class TestSendAgentToServerMessage:
         
         initial_seq = test_client.next_sequence_num
         
-        with patch('opamp.http_client.requests_odigos.post', side_effect=requests_odigos.Timeout("timeout")):
+        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("timeout")):
             test_client.send_agent_to_server_message(opamp_pb2.AgentToServer())
             assert test_client.next_sequence_num == initial_seq + 1
             
@@ -147,7 +147,7 @@ class TestSendAgentToServerMessage:
         ]
         
         for exc in exceptions_to_test:
-            with patch('opamp.http_client.requests_odigos.post', side_effect=exc):
+            with patch('opamp.transport.requests_odigos.post', side_effect=exc):
                 message = opamp_pb2.AgentToServer()
                 result = test_client.send_agent_to_server_message(message)
                 assert isinstance(result, opamp_pb2.ServerToAgent), f"Failed for exception: {exc}"

--- a/tests/opamp/test_transport.py
+++ b/tests/opamp/test_transport.py
@@ -1,0 +1,106 @@
+import os
+from unittest.mock import Mock, patch
+
+from opamp.transport import TCPTransport, UnixTransport, from_env
+
+
+# Test that the factory picks the right type for every env combination:
+# only ODIGOS_OPAMP_UNIX_SOCKET set → UnixTransport
+# only ODIGOS_OPAMP_SERVER_HOST set → TCPTransport
+# both set → UnixTransport wins (precedence guard)
+# neither set → None (fail-fast in mandatory_env_vars_set)
+class TestFromEnv:
+    """from_env() must pick the right transport for every supported env combination."""
+
+    def test_returns_unix_transport_when_only_unix_socket_set(self):
+        with patch.dict(os.environ, {"ODIGOS_OPAMP_UNIX_SOCKET": "/sock"}, clear=True):
+            result = from_env()
+        assert isinstance(result, UnixTransport)
+        assert result._socket_path == "/sock"
+
+    def test_returns_tcp_transport_when_only_server_host_set(self):
+        with patch.dict(os.environ, {"ODIGOS_OPAMP_SERVER_HOST": "odigos-server:4318"}, clear=True):
+            result = from_env()
+        assert isinstance(result, TCPTransport)
+        assert result._url == "http://odigos-server:4318/v1/opamp"
+
+    def test_unix_takes_precedence_when_both_set(self):
+        env = {
+            "ODIGOS_OPAMP_UNIX_SOCKET": "/sock",
+            "ODIGOS_OPAMP_SERVER_HOST": "odigos-server:4318",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = from_env()
+        assert isinstance(result, UnixTransport)
+
+    def test_returns_none_when_no_env_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = from_env()
+        assert result is None
+
+
+# When from_env() picks a transport, calling .post() on it must talk over the
+# matching wire (unix socket OR tcp) and never accidentally use the other one.
+# We don't send real traffic - we mock both wires and check which one was hit.
+class TestPostRoutesThroughCorrectWire:
+
+    def test_unix_transport_post_uses_unix_socket_and_not_requests(self):
+        # Env says "use unix". post() should open a unix connection and never call requests [py library].
+        mock_conn = Mock()
+        mock_response = Mock(status=200)
+        mock_response.read.return_value = b"unix-response"
+        mock_conn.getresponse.return_value = mock_response
+
+        with patch.dict(os.environ, {"ODIGOS_OPAMP_UNIX_SOCKET": "/sock"}, clear=True):
+            t = from_env()
+        assert isinstance(t, UnixTransport)
+
+        with (
+            patch("opamp.transport._UnixHTTPConnection", return_value=mock_conn) as unix_conn_cls,
+            patch("opamp.transport.requests_odigos.post") as tcp_post,
+        ):
+            data = t.post(b"hello", {"Content-Type": "x"}, timeout=5)
+
+        unix_conn_cls.assert_called_once_with("/sock", timeout=5)
+        mock_conn.request.assert_called_once_with("POST", "/v1/opamp", body=b"hello", headers={"Content-Type": "x"})
+        tcp_post.assert_not_called()
+        assert data == b"unix-response"
+
+    def test_tcp_transport_post_uses_requests_and_not_unix_socket(self):
+        # Env says "use tcp". post() should call requests_odigos and never open a unix connection.
+        mock_response = Mock(status_code=200, content=b"tcp-response")
+        mock_response.raise_for_status = Mock()
+
+        with patch.dict(os.environ, {"ODIGOS_OPAMP_SERVER_HOST": "host:1234"}, clear=True):
+            t = from_env()
+        assert isinstance(t, TCPTransport)
+
+        with (
+            patch("opamp.transport.requests_odigos.post", return_value=mock_response) as tcp_post,
+            patch("opamp.transport._UnixHTTPConnection") as unix_conn_cls,
+        ):
+            data = t.post(b"hello", {"Content-Type": "x"}, timeout=5)
+
+        tcp_post.assert_called_once_with(
+            "http://host:1234/v1/opamp",
+            data=b"hello",
+            headers={"Content-Type": "x"},
+            timeout=5,
+        )
+        unix_conn_cls.assert_not_called()
+        assert data == b"tcp-response"
+
+    # If the unix server responds with an HTTP error (>=400), post() must raise
+    # so the caller's try/except turns it into an empty ServerToAgent.
+    def test_unix_transport_raises_on_http_error_status(self):
+        mock_conn = Mock()
+        mock_conn.getresponse.return_value = Mock(status=500)
+
+        t = UnixTransport("/sock")
+        with patch("opamp.transport._UnixHTTPConnection", return_value=mock_conn):
+            try:
+                t.post(b"x", {}, timeout=1)
+            except RuntimeError as e:
+                assert "500" in str(e)
+            else:
+                raise AssertionError("expected RuntimeError on 500 status")

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.85"
+version = "1.0.86"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1416,7 +1416,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.85"
+version = "1.0.86"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Following https://github.com/odigos-io/odigos/pull/4916, which enabled the Odiglet OpAMP server to serve both HTTP over Unix socket and HTTP over TCP, we updated the Python implementation to support both transport methods. The instrumentor selects which environment variables to set based on runtime constraints, while the OpAMP server uses a factory to choose the transport layer for communication.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Python to support http over unix 
```
