### PR TITLE
CORE-1132: kafka consumer pods throws context errors

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.87"
+version = "1.0.88"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.87",
+    "odigos-opentelemetry-python == 1.0.88",
 ]
 
 [tool.uv.sources]

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/README.rst
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/README.rst
@@ -1,0 +1,23 @@
+OpenTelemetry confluent-kafka Instrumentation
+=============================================
+
+|pypi|
+
+.. |pypi| image:: https://badge.fury.io/py/opentelemetry-instrumentation-confluent-kafka.svg
+   :target: https://pypi.org/project/opentelemetry-instrumentation-confluent-kafka/
+
+This library allows tracing requests made by the confluent-kafka library.
+
+Installation
+------------
+
+::
+
+    pip install opentelemetry-instrumentation-confluent-kafka
+
+
+References
+----------
+
+* `OpenTelemetry confluent-kafka/ Tracing <https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/confluent_kafka/confluent_kafka.html>`_
+* `OpenTelemetry Project <https://opentelemetry.io/>`_

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "odigos-opentelemetry-instrumentation-confluent-kafka"
+dynamic = ["version"]
+description = "OpenTelemetry Confluent Kafka instrumentation"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+authors = [
+  { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "opentelemetry-instrumentation == 0.61b0",
+  "opentelemetry-api ~= 1.12",
+  "wrapt >= 1.0.0, < 2.0.0",
+]
+
+[project.optional-dependencies]
+instruments = [
+  "confluent-kafka >= 1.8.2, <= 2.13.0",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+confluent_kafka = "opentelemetry.instrumentation.confluent_kafka:ConfluentKafkaInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-confluent-kafka"
+Repository = "https://github.com/open-telemetry/opentelemetry-python-contrib"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/confluent_kafka/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -1,0 +1,433 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Instrument confluent-kafka-python to report instrumentation-confluent-kafka produced and consumed messages
+
+Usage
+-----
+
+.. code:: python
+
+    from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    from confluent_kafka import Producer, Consumer
+
+    # Instrument kafka
+    ConfluentKafkaInstrumentor().instrument()
+
+    # report a span of type producer with the default settings
+    conf1 = {'bootstrap.servers': "localhost:9092"}
+    producer = Producer(conf1)
+    producer.produce('my-topic',b'raw_bytes')
+    conf2 = {'bootstrap.servers': "localhost:9092", 'group.id': "foo", 'auto.offset.reset': 'smallest'}
+    # report a span of type consumer with the default settings
+    consumer = Consumer(conf2)
+
+    def msg_process(msg):
+        print(msg)
+
+    def basic_consume_loop(consumer, topics):
+        try:
+            consumer.subscribe(topics)
+            running = True
+            while running:
+                msg = consumer.poll(timeout=1.0)
+                if msg is None: continue
+                if msg.error():
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+                        # End of partition event
+                        sys.stderr.write(f"{msg.topic()} [{msg.partition()}] reached end at offset {msg.offset()}")
+                    elif msg.error():
+                        raise KafkaException(msg.error())
+                else:
+                    msg_process(msg)
+        finally:
+            # Close down consumer to commit final offsets.
+            consumer.close()
+
+    basic_consume_loop(consumer, ["my-topic"])
+
+The _instrument method accepts the following keyword args:
+  tracer_provider (TracerProvider) - an optional tracer provider
+
+  instrument_producer (Callable) - a function with extra user-defined logic to be performed before sending the message
+    this function signature is:
+
+  def instrument_producer(producer: Producer, tracer_provider=None)
+
+    instrument_consumer (Callable) - a function with extra user-defined logic to be performed after consuming a message
+        this function signature is:
+
+  def instrument_consumer(consumer: Consumer, tracer_provider=None)
+    for example:
+
+.. code:: python
+
+    from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    from opentelemetry.trace import get_tracer_provider
+
+    from confluent_kafka import Producer, Consumer
+
+    inst = ConfluentKafkaInstrumentor()
+    tracer_provider = get_tracer_provider()
+
+    p = Producer({'bootstrap.servers': 'localhost:9092'})
+    c = Consumer({
+        'bootstrap.servers': 'localhost:9092',
+        'group.id': 'mygroup',
+        'auto.offset.reset': 'earliest'
+    })
+
+    # instrument confluent kafka with produce and consume hooks
+    p = inst.instrument_producer(p, tracer_provider)
+    c = inst.instrument_consumer(c, tracer_provider=tracer_provider)
+
+    # Using kafka as normal now will automatically generate spans,
+    # including user custom attributes added from the hooks
+    conf = {'bootstrap.servers': "localhost:9092"}
+    p.produce('my-topic',b'raw_bytes')
+    msg = c.poll()
+
+"""
+
+from typing import Collection
+
+import confluent_kafka
+import wrapt
+from confluent_kafka import Consumer, Producer
+
+from opentelemetry import context, propagate, trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MessagingOperationTypeValues,
+)
+from opentelemetry.trace import Tracer
+
+from .package import _instruments
+from .utils import (
+    KafkaPropertiesExtractor,
+    _create_new_consume_span,
+    _end_current_consume_span,
+    _enrich_span,
+    _get_span_name,
+    _kafka_setter,
+)
+from .version import __version__
+
+
+class AutoInstrumentedProducer(Producer):
+    # This method is deliberately implemented in order to allow wrapt to wrap this function
+    def produce(self, topic, value=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg,useless-super-delegation
+        super().produce(topic, value, *args, **kwargs)
+
+
+class AutoInstrumentedConsumer(Consumer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._current_consume_span = None
+
+    # This method is deliberately implemented in order to allow wrapt to wrap this function
+    def poll(self, timeout=-1):  # pylint: disable=useless-super-delegation
+        return super().poll(timeout)
+
+    # This method is deliberately implemented in order to allow wrapt to wrap this function
+    def consume(self, *args, **kwargs):  # pylint: disable=useless-super-delegation
+        return super().consume(*args, **kwargs)
+
+    # This method is deliberately implemented in order to allow wrapt to wrap this function
+    def close(self):  # pylint: disable=useless-super-delegation
+        return super().close()
+
+
+class ProxiedProducer(Producer):
+    def __init__(self, producer: Producer, tracer: Tracer):
+        self._producer = producer
+        self._tracer = tracer
+
+    def flush(self, timeout=-1):
+        return self._producer.flush(timeout)
+
+    def poll(self, timeout=-1):
+        return self._producer.poll(timeout)
+
+    def purge(self, in_queue=True, in_flight=True, blocking=True):
+        self._producer.purge(in_queue, in_flight, blocking)
+
+    def produce(self, topic, value=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
+        new_kwargs = kwargs.copy()
+        new_kwargs["topic"] = topic
+        new_kwargs["value"] = value
+
+        return ConfluentKafkaInstrumentor.wrap_produce(
+            self._producer.produce, self, self._tracer, args, new_kwargs
+        )
+
+    def original_producer(self):
+        return self._producer
+
+
+class ProxiedConsumer(Consumer):
+    def __init__(self, consumer: Consumer, tracer: Tracer):
+        self._consumer = consumer
+        self._tracer = tracer
+        self._current_consume_span = None
+        self._current_context_token = None
+        # See ProxiedProducer.__init__ for rationale.
+        self.config = getattr(consumer, "config", None)
+
+    def close(self, *args, **kwargs):
+        return ConfluentKafkaInstrumentor.wrap_close(
+            self._consumer.close, self, args, kwargs
+        )
+
+    def committed(self, partitions, timeout=-1):
+        return self._consumer.committed(partitions, timeout)
+
+    def commit(self, *args, **kwargs):
+        return self._consumer.commit(*args, **kwargs)
+
+    def consume(self, *args, **kwargs):
+        return ConfluentKafkaInstrumentor.wrap_consume(
+            self._consumer.consume,
+            self,
+            self._tracer,
+            args,
+            kwargs,
+        )
+
+    def get_watermark_offsets(self, partition, timeout=-1, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
+        return self._consumer.get_watermark_offsets(
+            partition, timeout, *args, **kwargs
+        )
+
+    def offsets_for_times(self, partitions, timeout=-1):
+        return self._consumer.offsets_for_times(partitions, timeout)
+
+    def poll(self, timeout=-1):
+        return ConfluentKafkaInstrumentor.wrap_poll(
+            self._consumer.poll, self, self._tracer, [timeout], {}
+        )
+
+    def subscribe(self, topics, on_assign=lambda *args: None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
+        self._consumer.subscribe(topics, on_assign, *args, **kwargs)
+
+    def original_consumer(self):
+        return self._consumer
+
+
+class ConfluentKafkaInstrumentor(BaseInstrumentor):
+    """An instrumentor for confluent kafka module
+    See `BaseInstrumentor`
+    """
+
+    # pylint: disable=attribute-defined-outside-init
+    @staticmethod
+    def instrument_producer(
+        producer: Producer, tracer_provider=None
+    ) -> ProxiedProducer:
+        tracer = trace.get_tracer(
+            __name__,
+            __version__,
+            tracer_provider=tracer_provider,
+            schema_url="https://opentelemetry.io/schemas/1.11.0",
+        )
+
+        manual_producer = ProxiedProducer(producer, tracer)
+
+        return manual_producer
+
+    @staticmethod
+    def instrument_consumer(
+        consumer: Consumer, tracer_provider=None
+    ) -> ProxiedConsumer:
+        tracer = trace.get_tracer(
+            __name__,
+            __version__,
+            tracer_provider=tracer_provider,
+            schema_url="https://opentelemetry.io/schemas/1.11.0",
+        )
+
+        manual_consumer = ProxiedConsumer(consumer, tracer)
+
+        return manual_consumer
+
+    @staticmethod
+    def uninstrument_producer(producer: Producer) -> Producer:
+        if isinstance(producer, ProxiedProducer):
+            return producer.original_producer()
+        return producer
+
+    @staticmethod
+    def uninstrument_consumer(consumer: Consumer) -> Consumer:
+        if isinstance(consumer, ProxiedConsumer):
+            return consumer.original_consumer()
+        return consumer
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        # TODO: should probably wrap methods directly instead of going through
+        # these classes. Hopefully it'll make the patching work if called after
+        # the original classes have already been imported,  #4270
+        self._original_kafka_producer = confluent_kafka.Producer
+        self._original_kafka_consumer = confluent_kafka.Consumer
+
+        confluent_kafka.Producer = AutoInstrumentedProducer
+        confluent_kafka.Consumer = AutoInstrumentedConsumer
+
+        tracer_provider = kwargs.get("tracer_provider")
+        tracer = trace.get_tracer(
+            __name__,
+            __version__,
+            tracer_provider=tracer_provider,
+            schema_url="https://opentelemetry.io/schemas/1.11.0",
+        )
+
+        self._tracer = tracer
+
+        def _inner_wrap_produce(func, instance, args, kwargs):
+            return ConfluentKafkaInstrumentor.wrap_produce(
+                func, instance, self._tracer, args, kwargs
+            )
+
+        def _inner_wrap_poll(func, instance, args, kwargs):
+            return ConfluentKafkaInstrumentor.wrap_poll(
+                func, instance, self._tracer, args, kwargs
+            )
+
+        def _inner_wrap_consume(func, instance, args, kwargs):
+            return ConfluentKafkaInstrumentor.wrap_consume(
+                func, instance, self._tracer, args, kwargs
+            )
+
+        def _inner_wrap_close(func, instance, args, kwargs):
+            return ConfluentKafkaInstrumentor.wrap_close(
+                func, instance, args, kwargs
+            )
+
+        wrapt.wrap_function_wrapper(
+            AutoInstrumentedProducer,
+            "produce",
+            _inner_wrap_produce,
+        )
+
+        wrapt.wrap_function_wrapper(
+            AutoInstrumentedConsumer,
+            "poll",
+            _inner_wrap_poll,
+        )
+
+        wrapt.wrap_function_wrapper(
+            AutoInstrumentedConsumer,
+            "consume",
+            _inner_wrap_consume,
+        )
+
+        wrapt.wrap_function_wrapper(
+            AutoInstrumentedConsumer,
+            "close",
+            _inner_wrap_close,
+        )
+
+    def _uninstrument(self, **kwargs):
+        confluent_kafka.Producer = self._original_kafka_producer
+        confluent_kafka.Consumer = self._original_kafka_consumer
+
+        unwrap(AutoInstrumentedProducer, "produce")
+        unwrap(AutoInstrumentedConsumer, "poll")
+
+    @staticmethod
+    def wrap_produce(func, instance, tracer, args, kwargs):
+        topic = kwargs.get("topic")
+        if not topic:
+            topic = args[0]
+
+        span_name = _get_span_name("send", topic)
+        with tracer.start_as_current_span(
+            name=span_name, kind=trace.SpanKind.PRODUCER
+        ) as span:
+            headers = KafkaPropertiesExtractor.extract_produce_headers(
+                args, kwargs
+            )
+            if headers is None:
+                headers = []
+                kwargs["headers"] = headers
+
+            topic = KafkaPropertiesExtractor.extract_produce_topic(
+                args, kwargs
+            )
+            _enrich_span(
+                span,
+                topic,
+                operation=MessagingOperationTypeValues.RECEIVE,
+            )  # Replace
+            propagate.inject(
+                headers,
+                setter=_kafka_setter,
+            )
+            return func(*args, **kwargs)
+
+    @staticmethod
+    def wrap_poll(func, instance, tracer, args, kwargs):
+        if instance._current_consume_span:
+            _end_current_consume_span(instance)
+
+        with tracer.start_as_current_span(
+            "recv", end_on_exit=True, kind=trace.SpanKind.CONSUMER
+        ):
+            record = func(*args, **kwargs)
+            if record:
+                _create_new_consume_span(instance, tracer, [record])
+                _enrich_span(
+                    instance._current_consume_span,
+                    record.topic(),
+                    record.partition(),
+                    record.offset(),
+                    operation=MessagingOperationTypeValues.PROCESS,
+                )
+            instance._current_context_token = context.attach(
+                trace.set_span_in_context(instance._current_consume_span)
+            )
+
+        return record
+
+    @staticmethod
+    def wrap_consume(func, instance, tracer, args, kwargs):
+        if instance._current_consume_span:
+            _end_current_consume_span(instance)
+
+        with tracer.start_as_current_span(
+            "recv", end_on_exit=True, kind=trace.SpanKind.CONSUMER
+        ):
+            records = func(*args, **kwargs)
+            if len(records) > 0:
+                _create_new_consume_span(instance, tracer, records)
+                _enrich_span(
+                    instance._current_consume_span,
+                    records[0].topic(),
+                    operation=MessagingOperationTypeValues.PROCESS,
+                )
+            instance._current_context_token = context.attach(
+                trace.set_span_in_context(instance._current_consume_span)
+            )
+
+        return records
+
+    @staticmethod
+    def wrap_close(func, instance, args, kwargs):
+        if instance._current_consume_span:
+            _end_current_consume_span(instance)
+        func(*args, **kwargs)

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/__init__.py
@@ -107,7 +107,7 @@ import confluent_kafka
 import wrapt
 from confluent_kafka import Consumer, Producer
 
-from opentelemetry import context, propagate, trace
+from opentelemetry import propagate, trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
@@ -183,7 +183,6 @@ class ProxiedConsumer(Consumer):
         self._consumer = consumer
         self._tracer = tracer
         self._current_consume_span = None
-        self._current_context_token = None
         # See ProxiedProducer.__init__ for rationale.
         self.config = getattr(consumer, "config", None)
 
@@ -398,10 +397,8 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
                     record.offset(),
                     operation=MessagingOperationTypeValues.PROCESS,
                 )
-            instance._current_context_token = context.attach(
-                trace.set_span_in_context(instance._current_consume_span)
-            )
-
+            # [Odigos fix] removed upstream context.attach of the consume span here
+            # (caused "Failed to detach context"); see _end_current_consume_span in utils.py
         return record
 
     @staticmethod
@@ -420,10 +417,8 @@ class ConfluentKafkaInstrumentor(BaseInstrumentor):
                     records[0].topic(),
                     operation=MessagingOperationTypeValues.PROCESS,
                 )
-            instance._current_context_token = context.attach(
-                trace.set_span_in_context(instance._current_consume_span)
-            )
-
+            # [Odigos fix] removed upstream context.attach of the consume span here
+            # (caused "Failed to detach context"); see _end_current_consume_span in utils.py
         return records
 
     @staticmethod

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_instruments = ("confluent-kafka >= 1.8.2, <= 2.13.0",)

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -1,0 +1,157 @@
+from logging import getLogger
+from typing import List, Optional
+
+from opentelemetry import context, propagate
+from opentelemetry.propagators import textmap
+from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
+    MESSAGING_MESSAGE_ID,
+    MESSAGING_OPERATION,
+    MESSAGING_SYSTEM,
+    MessagingOperationTypeValues,
+)
+from opentelemetry.semconv.trace import (
+    MessagingDestinationKindValues,
+    SpanAttributes,
+)
+from opentelemetry.trace import Link, SpanKind
+
+_LOG = getLogger(__name__)
+
+
+class KafkaPropertiesExtractor:
+    @staticmethod
+    def extract_bootstrap_servers(instance):
+        return instance.config.get("bootstrap_servers")
+
+    @staticmethod
+    def _extract_argument(key, position, default_value, args, kwargs):
+        if len(args) > position:
+            return args[position]
+        return kwargs.get(key, default_value)
+
+    @staticmethod
+    def extract_produce_topic(args, kwargs):
+        """extract topic from `produce` method arguments in Producer class"""
+        return kwargs.get("topic") or (args[0] if args else "unknown")
+
+    @staticmethod
+    def extract_produce_headers(args, kwargs):
+        """extract headers from `produce` method arguments in Producer class"""
+        return KafkaPropertiesExtractor._extract_argument(
+            "headers", 6, None, args, kwargs
+        )
+
+
+class KafkaContextGetter(textmap.Getter):
+    def get(self, carrier: textmap.CarrierT, key: str) -> Optional[List[str]]:
+        if carrier is None:
+            return None
+
+        carrier_items = carrier
+        if isinstance(carrier, dict):
+            carrier_items = carrier.items()
+
+        for item_key, value in carrier_items:
+            if item_key == key:
+                if value is not None:
+                    return [value.decode()]
+
+        return None
+
+    def keys(self, carrier: textmap.CarrierT) -> List[str]:
+        if carrier is None:
+            return []
+
+        carrier_items = carrier
+        if isinstance(carrier, dict):
+            carrier_items = carrier.items()
+        return [key for (key, value) in carrier_items]
+
+
+class KafkaContextSetter(textmap.Setter):
+    def set(self, carrier: textmap.CarrierT, key: str, value: str) -> None:
+        if carrier is None or key is None:
+            return
+
+        if value:
+            value = value.encode()
+
+        if isinstance(carrier, list):
+            carrier.append((key, value))
+
+        if isinstance(carrier, dict):
+            carrier[key] = value
+
+
+_kafka_getter = KafkaContextGetter()
+
+
+def _end_current_consume_span(instance):
+    if instance._current_context_token:
+        context.detach(instance._current_context_token)
+    instance._current_context_token = None
+    instance._current_consume_span.end()
+    instance._current_consume_span = None
+
+
+def _create_new_consume_span(instance, tracer, records):
+    links = _get_links_from_records(records)
+    instance._current_consume_span = tracer.start_span(
+        name=f"{records[0].topic()} process",
+        links=links,
+        kind=SpanKind.CONSUMER,
+    )
+
+
+def _get_links_from_records(records):
+    links = []
+    for record in records:
+        ctx = propagate.extract(record.headers(), getter=_kafka_getter)
+        if ctx:
+            for item in ctx.values():
+                if hasattr(item, "get_span_context"):
+                    links.append(Link(context=item.get_span_context()))
+
+    return links
+
+
+def _enrich_span(
+    span,
+    topic,
+    partition: Optional[int] = None,
+    offset: Optional[int] = None,
+    operation: Optional[MessagingOperationTypeValues] = None,
+):
+    if not span.is_recording():
+        return
+
+    span.set_attribute(MESSAGING_SYSTEM, "kafka")
+    span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, topic)
+
+    if partition is not None:
+        span.set_attribute(SpanAttributes.MESSAGING_KAFKA_PARTITION, partition)
+
+    span.set_attribute(
+        SpanAttributes.MESSAGING_DESTINATION_KIND,
+        MessagingDestinationKindValues.QUEUE.value,
+    )
+
+    if operation:
+        span.set_attribute(MESSAGING_OPERATION, operation.value)
+    else:
+        span.set_attribute(SpanAttributes.MESSAGING_TEMP_DESTINATION, True)
+
+    # https://stackoverflow.com/questions/65935155/identify-and-find-specific-message-in-kafka-topic
+    # A message within Kafka is uniquely defined by its topic name, topic partition and offset.
+    if partition is not None and offset is not None and topic:
+        span.set_attribute(
+            MESSAGING_MESSAGE_ID,
+            f"{topic}.{partition}.{offset}",
+        )
+
+
+_kafka_setter = KafkaContextSetter()
+
+
+def _get_span_name(operation: str, topic: str):
+    return f"{topic} {operation}"

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/utils.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from typing import List, Optional
 
-from opentelemetry import context, propagate
+from opentelemetry import propagate
 from opentelemetry.propagators import textmap
 from opentelemetry.semconv._incubating.attributes.messaging_attributes import (
     MESSAGING_MESSAGE_ID,
@@ -87,9 +87,11 @@ _kafka_getter = KafkaContextGetter()
 
 
 def _end_current_consume_span(instance):
-    if instance._current_context_token:
-        context.detach(instance._current_context_token)
-    instance._current_context_token = None
+    # [Odigos fix] 
+    # Upstream tried to detach a context token here (context.detach) that was attached at the end of the previous poll()/consume(). 
+    # When an app processes each message in its own contextvars.Context, that detach ran in a different Context and
+    # raised a ValueError with "Failed to detach context". 
+    # We removed the cross-call attach (see wrap_poll / wrap_consume), so there is no token to detach — we only end the span.
     instance._current_consume_span.end()
     instance._current_consume_span = None
 

--- a/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
+++ b/instrumentations/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/version.py
@@ -1,0 +1,4 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "0.61b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "opentelemetry-instrumentation-cassandra == 0.61b0",
     "opentelemetry-instrumentation-celery == 0.61b0",
     "opentelemetry-instrumentation-click == 0.61b0",
-    "opentelemetry-instrumentation-confluent-kafka == 0.61b0",
+    "odigos-opentelemetry-instrumentation-confluent-kafka == 0.61b0",
     "opentelemetry-instrumentation-dbapi == 0.61b0",
     "opentelemetry-instrumentation-django == 0.61b0",
     "odigos-opentelemetry-instrumentation-elasticsearch == 0.61b0",
@@ -108,6 +108,7 @@ odigos = "initializer.distro.distro:OdigosDistro"
 [tool.uv.sources]
 odigos-opentelemetry-instrumentation-aiohttp-server = { workspace = true }
 odigos-opentelemetry-instrumentation-elasticsearch = { workspace = true }
+odigos-opentelemetry-instrumentation-confluent-kafka = { workspace = true }
 odigos-opentelemetry-instrumentation-openai-v2 = { workspace = true }
 odigos-opentelemetry-instrumentation-sqlalchemy = { workspace = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.87"
+version = "1.0.88"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.87"
+version = "1.0.88"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1482,7 +1482,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.87"
+version = "1.0.88"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ resolution-markers = [
 [manifest]
 members = [
     "odigos-opentelemetry-instrumentation-aiohttp-server",
+    "odigos-opentelemetry-instrumentation-confluent-kafka",
     "odigos-opentelemetry-instrumentation-elasticsearch",
     "odigos-opentelemetry-instrumentation-openai-v2",
     "odigos-opentelemetry-instrumentation-sqlalchemy",
@@ -363,6 +364,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "confluent-kafka"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/d0/1f5055331fa660225de6829b143e6f083913f0a96481134a91390bad62c1/confluent_kafka-2.13.0.tar.gz", hash = "sha256:eff7a4391a9e6d4a33f0c05d0935b200a7463834f1f5d6e6253be318f910babd", size = 273621, upload-time = "2026-01-05T10:25:08.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/75/b3ac0e7fc74a577eb58872f07faef3d1d50a1e1ac7d105b167d330105bc5/confluent_kafka-2.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:264f86956d3bbd26bc14fd2d4060908a0c53d26b14ff33d21fa83369f55d8d3b", size = 3626152, upload-time = "2026-01-05T10:23:21.034Z" },
+    { url = "https://files.pythonhosted.org/packages/17/7c/897913554793d43fcf69e0bfa1ba2b647e007f45fa43b190645e5b5f6518/confluent_kafka-2.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4af5f129acce30110c7a1c9c05c54821c1283850e38c67715bed7c3c8df322c6", size = 3186880, upload-time = "2026-01-05T10:23:24.382Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/c956373d15a57290b9d00c5e2c1a5fb65b8d4f77fa64535ad7370d9ed750/confluent_kafka-2.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9b975664e821d975c85ec9bba806b7c62eb9b23cf2ad3b41813862ee24caf00e", size = 3715940, upload-time = "2026-01-05T10:23:29.266Z" },
+    { url = "https://files.pythonhosted.org/packages/10/92/66179579a1bbc91f2e700841ea698a99c8108580e46c2cd5b1812c707c38/confluent_kafka-2.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fc633deedd3eba5c266bf12959d8c4173806d252db45d2c78d3bd9a874dc7ccf", size = 3973310, upload-time = "2026-01-05T10:23:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e6/66d3bd816d996058f9f46b46953e79b3ea2662f3538d0682a3f52f651393/confluent_kafka-2.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:2c0b19a83f519de8f2cb170bc7879b1d92ac342a75798722fbfe29965f21d5ad", size = 4093322, upload-time = "2026-01-05T10:23:34.235Z" },
+    { url = "https://files.pythonhosted.org/packages/94/57/a90b9042a06bfbb8cc1e50142b8bcea29fde57a528dc10b188835e7c5c53/confluent_kafka-2.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:af19d6a2ab49f02cf699bc1dfb6f4bdcc3588e077c7b5319d73335b81fef93fd", size = 3625719, upload-time = "2026-01-05T10:23:36.469Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ee/d0839c64de344de247d80b6f69a2d7f5d781bb55bdd1e98793549780a34d/confluent_kafka-2.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a406800c29e568e61ab687540391ac8eab210b79d24d7eb41b75b6117882e269", size = 3186456, upload-time = "2026-01-05T10:23:38.742Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/6224ab1c5dad5d70717f3e018f1d676be1d54ce3ea08b04b1d19e94484dc/confluent_kafka-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9bc38055f5a26bec15ca81b0465f90cb2663a31c19948d6421dc02090b4cbd4a", size = 3715598, upload-time = "2026-01-05T10:23:41.018Z" },
+    { url = "https://files.pythonhosted.org/packages/64/88/a7a7ee4fdcca5340809482e6565cd3270fe82afd029a14cf921b51eef152/confluent_kafka-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7080a20f64293b1f81747748e6bda0d1e9a9d5d5f94cd1b0c625cfdf819f491f", size = 3972822, upload-time = "2026-01-05T10:23:44.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/46/2879be2a40b9b44a527a16c117c6a5f380fdd10d6735b43bce6fab6102d7/confluent_kafka-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:39fdfd4fa6371ebabf9e7be858ae68d4fa9a9fd72fd5fc3d739fdaa99997fd9a", size = 4093320, upload-time = "2026-01-05T10:23:46.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/6bf9e5b3ee4bfdb39d3fcc7efabc9f577aa51e9e20139adc8d10e61593a5/confluent_kafka-2.13.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a69263f22a8c53c7d55067e7795ed49d22c374b9473df91982816a0448e6d242", size = 3631367, upload-time = "2026-01-05T10:23:48.076Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3d/c299df69885be6fdfc8b105b8106b2b4c73c745fa608cf579eb7e14a3da9/confluent_kafka-2.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0945c7f529e66a18aa19135aa18bfdc239ca6c0f6df6ca9b05a793d9b76c1c4b", size = 3191073, upload-time = "2026-01-05T10:23:49.967Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2e/854aedcd9c9042491c1fcafaadc03a3b0e357ddc23044781d02920b46ea2/confluent_kafka-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:321037a64c02acb13b5bde193b461c0514dca236a9f5236c847a3240313c297f", size = 3720530, upload-time = "2026-01-05T10:23:51.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4a/210f0e1f8e77956ed1296c8b9bac2093413c1669ea0e923f590f2827aa1a/confluent_kafka-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d7a71ca8fd42d3eefa22eb202e7fc8a419e0fd4e3b59862918c21f4d1074f0c5", size = 3977296, upload-time = "2026-01-05T10:23:56.743Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/bc/d51f48200bb7bec521289c0b70691ea73f91aa76529b1bff807bcbf89b12/confluent_kafka-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:37dddb1b92829b8862bc4fbce07789a79b73aa31eca413f3db187721a09975ff", size = 4093802, upload-time = "2026-01-05T10:23:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bd/c2ab440b4c4847a37b21e9623bbeaf17982ca45595ad62b8435a26d680f7/confluent_kafka-2.13.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:0af90b3c566786017a01693da0ec4a876ca14cf37bc6164872652a6cf2702453", size = 3195849, upload-time = "2026-01-05T10:24:00.854Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/a25a5895cf522bada81fc7ba6c0ad29219843206ede4e8d2138b7b095652/confluent_kafka-2.13.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:f25d05604dd92e9de72707582dded53aeb4737ef2e2c097a3ca08650200fc446", size = 3634806, upload-time = "2026-01-05T10:24:05.496Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/46/db30d27184ac8fb673ca469d576ef582def0b613a69456631734f7a5e267/confluent_kafka-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:74ddf5ec7fa6058221a619c850f44bdbe8d969d7ed6efe8abdc857d2e233df20", size = 3720848, upload-time = "2026-01-05T10:24:07.831Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f8/5b940a080ab71fc3c585839eae0c26341a749a7ebc001fca0276aff9df40/confluent_kafka-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f8d1d00397f3f32a1bcf4604d4164bf75838bd009e1e28282a7ae25e16814ea4", size = 3977677, upload-time = "2026-01-05T10:24:09.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cf/f9f979c08cfe1b8fd9203b329fc5c8c410e948f01272434bc1ce0c6334a5/confluent_kafka-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9d1fd035e2c47c4db5fe9b0f59a28fe2f2f1012887290dd0ea7d46741f686e99", size = 4153481, upload-time = "2026-01-05T10:24:12.167Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3f/c2120c002f85c5401d8ea29558acf041ad968b33cfca83916a7c0a740d53/confluent_kafka-2.13.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:d448537147a33dd8c17656732989ddfe1d4a25a40bcb5f59bc63dc0a5041dd83", size = 3195696, upload-time = "2026-01-05T10:24:14.422Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b9/da4ef8fca4cbc76b6040a97a92085c09c0f23c42424989a2d68cec42c8d6/confluent_kafka-2.13.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:1325585f9fc283c32c30df4226178dc89cf43d00f5c240e1f77ddedc94573690", size = 3634632, upload-time = "2026-01-05T10:24:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ed/c7d5cc3c57aec126ffb12ffa5f4584acd264446a4117db3ad2dd69e47afe/confluent_kafka-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:266bbea18ce99f6e77ce0e9a118f353447c8705792ef5745eabcc5c6db08794a", size = 3720650, upload-time = "2026-01-05T10:24:18.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2b/0a93b63a46b2ceaac3de92d494e32aab21bec398b40ac89108bbaa6894c3/confluent_kafka-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:7a373a1a3dd8e02dd218946583e951791480921fd777faeaf601c2834e2a6c0d", size = 3977364, upload-time = "2026-01-05T10:24:23.677Z" },
+    { url = "https://files.pythonhosted.org/packages/46/00/80ea6872421c4e30e033e035e5bdcf44c054993d5721623841c59b5f04c1/confluent_kafka-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:da956b2141d9f425dbfc3cf1c244ef6d0633b83fc5ceada6f496099258e63a68", size = 4271874, upload-time = "2026-01-05T10:24:26.265Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1a/e6fe016bea63343010f485a1ecebfdc00d9b6e95ef6fe52a1d7793c0339c/confluent_kafka-2.13.0-cp314-cp314t-macosx_13_0_arm64.whl", hash = "sha256:fa354e9fb95e26545decd429477072ea3a98a2e7acac11d09156772e06f14680", size = 3194480, upload-time = "2026-01-05T10:24:28.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/54/c9668f214f2e736e51e2874053fe1ebcb8784425fefcfd6fd0d384dc5dcf/confluent_kafka-2.13.0-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:e256dc3a993bf5fde0fa4a1b6a5b72e3521cedbc9dc4d7a65f159afa4b72e5b4", size = 3632866, upload-time = "2026-01-05T10:24:30.689Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/83e989962077003d91ba249158c7a1e21696604c301b3680fcbb427005d0/confluent_kafka-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:eb7988038b7f13ea490af93b9165ed40a3f385fb91e99ce8dacee8890e36e48a", size = 3718956, upload-time = "2026-01-05T10:24:33.035Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/84/1aaa5cfe1695f02d11e02ef39f180567780348b1f3e1161575f002a207fe/confluent_kafka-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cfd8f011b0b0a109f8747312dba6cee45b39fb53fc7d53f28813bce84a91228d", size = 3976235, upload-time = "2026-01-05T10:24:35.122Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/7b/fda0b6629552718ec05e3f6a821625963b8c50ab5d27079141c426048a30/confluent_kafka-2.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:85247f23d3f043f06e83181b63c27e48c6f461c4b2211ca67205f54f27f1867d", size = 3626372, upload-time = "2026-01-05T10:24:52.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/98/29900f861ac5659ba6d8ce28e36e5590ab9da3ef6d842d3bd08ea37acf2f/confluent_kafka-2.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e35cbe76a5e784397688fb0d2f30eabfc60c320b78bfc5656b17c126e92e7da4", size = 3187126, upload-time = "2026-01-05T10:24:57.073Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/3975e97b201321c322aabfecadad95173cf4619b86a2e813204588df5b47/confluent_kafka-2.13.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:a5c59119fcdec13c75448e11f13273c026265fb85fc8e49fec186bca581464a9", size = 3715916, upload-time = "2026-01-05T10:25:00.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/48/1b86522d6c6ded945a80a5572d1833f5a9d2d28b7465d941af6dff98708d/confluent_kafka-2.13.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:0f746467574477b419b42d9ce65df1c9325aa4ad54d4239f19d19018620d77c4", size = 3973500, upload-time = "2026-01-05T10:25:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/64/ffe4c1bb9c17083a865ee1b08b80e87685f687f4af6c308014d80c9f2af0/confluent_kafka-2.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc5d9fde588485fe2c5f760678733406d0894eb2df6e7a2fb36769633c840a48", size = 4094385, upload-time = "2026-01-05T10:25:06.481Z" },
 ]
 
 [[package]]
@@ -1161,6 +1204,29 @@ requires-dist = [
 provides-extras = ["instruments"]
 
 [[package]]
+name = "odigos-opentelemetry-instrumentation-confluent-kafka"
+source = { editable = "instrumentations/opentelemetry-instrumentation-confluent-kafka" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+
+[package.optional-dependencies]
+instruments = [
+    { name = "confluent-kafka" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "confluent-kafka", marker = "extra == 'instruments'", specifier = ">=1.8.2,<=2.13.0" },
+    { name = "opentelemetry-api", specifier = "~=1.12" },
+    { name = "opentelemetry-instrumentation", specifier = "==0.61b0" },
+    { name = "wrapt", specifier = ">=1.0.0,<2.0.0" },
+]
+provides-extras = ["instruments"]
+
+[[package]]
 name = "odigos-opentelemetry-instrumentation-elasticsearch"
 source = { editable = "instrumentations/opentelemetry-instrumentation-elasticsearch" }
 dependencies = [
@@ -1248,6 +1314,7 @@ dependencies = [
     { name = "idna" },
     { name = "importlib-metadata" },
     { name = "odigos-opentelemetry-instrumentation-aiohttp-server" },
+    { name = "odigos-opentelemetry-instrumentation-confluent-kafka" },
     { name = "odigos-opentelemetry-instrumentation-elasticsearch" },
     { name = "odigos-opentelemetry-instrumentation-openai-v2" },
     { name = "odigos-opentelemetry-instrumentation-sqlalchemy" },
@@ -1267,7 +1334,6 @@ dependencies = [
     { name = "opentelemetry-instrumentation-cassandra" },
     { name = "opentelemetry-instrumentation-celery" },
     { name = "opentelemetry-instrumentation-click" },
-    { name = "opentelemetry-instrumentation-confluent-kafka" },
     { name = "opentelemetry-instrumentation-dbapi" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-falcon" },
@@ -1338,6 +1404,7 @@ requires-dist = [
     { name = "idna", specifier = "==3.10" },
     { name = "importlib-metadata", specifier = "==6.0" },
     { name = "odigos-opentelemetry-instrumentation-aiohttp-server", editable = "instrumentations/opentelemetry-instrumentation-aiohttp-server" },
+    { name = "odigos-opentelemetry-instrumentation-confluent-kafka", editable = "instrumentations/opentelemetry-instrumentation-confluent-kafka" },
     { name = "odigos-opentelemetry-instrumentation-elasticsearch", editable = "instrumentations/opentelemetry-instrumentation-elasticsearch" },
     { name = "odigos-opentelemetry-instrumentation-openai-v2", editable = "instrumentations/opentelemetry-instrumentation-openai-v2" },
     { name = "odigos-opentelemetry-instrumentation-sqlalchemy", editable = "instrumentations/opentelemetry-instrumentation-sqlalchemy" },
@@ -1357,7 +1424,6 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-cassandra", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-celery", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-click", specifier = "==0.61b0" },
-    { name = "opentelemetry-instrumentation-confluent-kafka", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-dbapi", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-django", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-falcon", specifier = "==0.61b0" },
@@ -1709,20 +1775,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/a1/8f800ebacb0eddc355d6b1e306edb8ba67e94e8aa8b907adbc75972e2be9/opentelemetry_instrumentation_click-0.61b0.tar.gz", hash = "sha256:85a85c7b144503d03a8529b8991363d9ba571d3c539f5d3e94517ac0659abcfb", size = 4219, upload-time = "2026-03-04T14:20:28.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/17/35d96193f3ddba62a32dda44c9ee69da765562326608c3d9ab8c135d5a6d/opentelemetry_instrumentation_click-0.61b0-py3-none-any.whl", hash = "sha256:0c4ed76a8f67d62f1033b603351ad87e72eb174f02a818e198d88346ac59498b", size = 5026, upload-time = "2026-03-04T14:19:22.251Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-confluent-kafka"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/0e/76db8f0f41678da1c50926367eaf7c3a984cb849235e83b699ad801341b0/opentelemetry_instrumentation_confluent_kafka-0.61b0.tar.gz", hash = "sha256:06c7a13b0ccfa77701d90df19e755e92f3ae3ca6f88c0b1cca64700b4ea1af78", size = 11900, upload-time = "2026-03-04T14:20:29.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/a2/0a79dcd319a7a8de6aaf91ba1ca1d995a51e63ca0fbf545ae0eeec993a81/opentelemetry_instrumentation_confluent_kafka-0.61b0-py3-none-any.whl", hash = "sha256:2ce36aa3287b870c30b62584090360d591d882f179da07d729f009d442799f16", size = 12810, upload-time = "2026-03-04T14:19:23.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
A customer had this error:
```
Traceback (most recent call last):  
 File "/var/odigos/python/opentelemetry/context/__init__.py", line 155, in detach  
   _RUNTIME_CONTEXT.detach(token)  
 File "/var/odigos/python/opentelemetry/context/contextvars_context.py", line 53, in detach  
   self._current_context.reset(token)  
ValueError: <Token var=<ContextVar name='current_context' default={} at 0xea8d89e7fe20> at 0xea8d...> was created in a different Context
```

This is caused by the `consume()` and `poll()` functions, which after consuming a kafka message and generates a span, it detaches a context variable token.
Since `consume()`/`poll()` and `detach()` run in different contexts, the operation for removing the context var throws a ValueError
De facto it isn't a viable/relevant operation (=each kafka message consumed has its own context anyway) so we can remove its usage in the `attach()`/`detach()` loop.

To solve this:
1. I vendored the confluent-kafka instrumentation into the odigos python package
2. Removed the context var usage in attach/detach

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix a confluent kafka error which showed a faulty operation on context (throw ValueError)
```
