### PR TITLE
CORE-1205: sampling fixes

### DIFF
--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -178,7 +178,8 @@ class OdigosSampler(Sampler):
         if server_address:
             server_address = strip_port(server_address)
         else:
-            # some instrumentations (like urllib) never puts a host attribute on the span. it sets only method + url, so if we want the host we need to extract it from the full url
+            # some instrumentations (like urllib) never puts a host attribute on the span. it sets only method + url,
+            # so if we want the host we need to extract it from the full url
             # default (old) semconv mode the full URL is http.url; in stable mode url.full.
             full_url = get_attribute(span_attributes, "url.full", "http.url")
             if full_url:

--- a/initializer/odigos_sampler.py
+++ b/initializer/odigos_sampler.py
@@ -98,10 +98,10 @@ class OdigosSampler(Sampler):
                     matched = True
                 else:  # When we have a granular operation, check it vs the server/client rules specified in the noisy operation
                     matched = False
-                    if http_server_sample := http_operation_sample.get("httpServer"):
+                    if (http_server_sample := http_operation_sample.get("httpServer")) and kind == SpanKind.SERVER:
                         matched = self._match_http_server_sample_rule(http_server_sample, attributes) or matched
 
-                    if http_client_sample := http_operation_sample.get("httpClient"):
+                    if (http_client_sample := http_operation_sample.get("httpClient")) and kind == SpanKind.CLIENT:
                         matched = self._match_http_client_sample_rule(http_client_sample, attributes) or matched
 
                 # sampler_logger.debug(f'Noisy operation matched: {matched}, percentage: {percentage_to_sample}')
@@ -156,8 +156,10 @@ class OdigosSampler(Sampler):
             if target:
                 return self._match_rule_route_to_span(http_server_rule["route"], target)
 
-        if http_server_rule.get("routePrefix") and not (span_route or "").startswith(http_server_rule["routePrefix"]):
-            return False
+        if route_prefix := http_server_rule.get("routePrefix"):
+            candidate = span_route or target
+            if not candidate or not self._match_rule_route_to_span(route_prefix, candidate, route_has_prefix=True):
+                return False
         if http_server_rule.get("method") and http_server_rule["method"] != span_method:
             return False
 
@@ -175,6 +177,12 @@ class OdigosSampler(Sampler):
         server_address = get_attribute(span_attributes, server_attributes_semconv.SERVER_ADDRESS, "net.peer.name", "http.host")
         if server_address:
             server_address = strip_port(server_address)
+        else:
+            # some instrumentations (like urllib) never puts a host attribute on the span. it sets only method + url, so if we want the host we need to extract it from the full url
+            # default (old) semconv mode the full URL is http.url; in stable mode url.full.
+            full_url = get_attribute(span_attributes, "url.full", "http.url")
+            if full_url:
+                server_address = urlsplit(full_url).hostname
 
         # Old semconv for url is a target that we need to get the client_path from → new semconv: "url.template"/"url.path"
         client_path = get_attribute(span_attributes, "url.template", url_attributes_semconv.URL_PATH)

--- a/tests/unit/test_odigos_sampler.py
+++ b/tests/unit/test_odigos_sampler.py
@@ -222,6 +222,91 @@ class TestShouldSample:
         assert result.trace_state.get("odigos") is None
 
 
+class TestSpanKindGating:
+    """httpServer operations must only match SERVER spans and httpClient only CLIENT
+    spans. Regression test for ignoring health-probe rule."""
+
+    # Mirrors the real head-sampling-http-client InstrumentationConfig.
+    CONFIG = {
+        "noisyOperations": [
+            {
+                "id": "health",
+                "name": "kubelet health probe",
+                "percentageAtMost": 0,
+                "operation": {"httpServer": {"route": "/healthz", "method": "GET"}},
+            },
+            {
+                "id": "outbound-exact",
+                "percentageAtMost": 50,
+                "operation": {
+                    "httpClient": {
+                        "serverAddress": "head-sampling-http-server",
+                        "templatedPath": "/http-match/exact/target",
+                    }
+                },
+            },
+        ],
+    }
+
+    def test_health_server_rule_does_not_decide_client_span(self, sampler):
+        sampler.update_config(self.CONFIG)
+        # urllib client span: only http.url (no http.route / http.target / url.path).
+        result = sampler.should_sample(
+            parent_context=None,
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            name="GET",
+            kind=SpanKind.CLIENT,
+            attributes={
+                "http.method": "GET",
+                "http.url": "http://head-sampling-http-server:8080/http-match/exact/target",
+                "http.status_code": 200,
+            },
+        )
+        odigos_value = result.trace_state.get("odigos")
+        # The client exact rule (50%) must decide, not the 0% health-probe server rule.
+        assert "dr.id:outbound-exact" in odigos_value
+        assert "dr.p:50" in odigos_value
+        assert "dr.id:health" not in odigos_value
+
+    def test_health_server_rule_still_decides_server_probe_span(self, sampler):
+        sampler.update_config(self.CONFIG)
+        result = sampler.should_sample(
+            parent_context=None,
+            trace_id=0x0123456789ABCDEF0123456789ABCDEF,
+            name="GET /healthz",
+            kind=SpanKind.SERVER,
+            attributes={"http.method": "GET", "http.route": "/healthz"},
+        )
+        assert "dr.id:health" in result.trace_state.get("odigos")
+
+
+class TestHttpServerRoutePrefix:
+    """routePrefix must match per-segment with wildcard support, not literal startswith,
+    so templated routes (e.g. /http-match/tprefix/<tenant_id>/items) match a rule
+    routePrefix of /http-match/tprefix/*/items."""
+
+    RULE = {"routePrefix": "/http-match/tprefix/*/items"}
+
+    @pytest.mark.parametrize(
+        "route, expected",
+        [
+            pytest.param("/http-match/tprefix/<tenant_id>/items", True, id="flask-templated"),
+            pytest.param("/http-match/tprefix/:tenantId/items", True, id="express-templated"),
+            pytest.param("/http-match/tprefix/{tenantId}/items", True, id="spring-templated"),
+            pytest.param("/http-match/tprefix/<tenant_id>/items/<item_id>", True, id="deeper-nested"),
+            pytest.param("/http-match/tprefix/<tenant_id>/orders", False, id="wrong-suffix"),
+            pytest.param("/http-match/exact/target", False, id="unrelated-route"),
+        ],
+    )
+    def test_route_prefix_wildcard_match(self, sampler, route, expected):
+        assert sampler._match_http_server_sample_rule(self.RULE, {"http.route": route}) is expected
+
+    def test_literal_prefix_still_matches(self, sampler):
+        # Non-wildcard routePrefix must still match deeper concrete routes.
+        rule = {"routePrefix": "/http-match/prefix"}
+        assert sampler._match_http_server_sample_rule(rule, {"http.route": "/http-match/prefix/segment"}) is True
+
+
 class TestDryRun:
     """Tests for dry-run mode: spans must NEVER be dropped, but tracestate must
     record the would-be decision as `;dry:t` (kept) or `;dry:f` (dropped).
@@ -454,10 +539,20 @@ class TestHttpClientSemconv:
             pytest.param({"net.peer.name": "payments"}, id="old-net.peer.name"),
             pytest.param({"http.host": "payments"}, id="old-http.host-no-port"),
             pytest.param({"http.host": "payments:8080"}, id="old-http.host-with-port"),
+            # urllib emits no host attr; host must be derived from the full URL.
+            pytest.param({"url.full": "http://payments:8080/p"}, id="urllib-new-url.full"),
+            pytest.param({"http.url": "http://payments:8080/p"}, id="urllib-old-http.url"),
         ],
     )
     def test_server_address_matches_across_semconv(self, sampler, attributes):
         rule = {"serverAddress": "payments"}
+        assert sampler._match_http_client_sample_rule(rule, attributes) is True
+
+    def test_urllib_client_matches_server_address_and_path_from_full_url(self, sampler):
+        # opentelemetry-instrumentation-urllib sets only the full URL (no server.address,
+        # net.peer.name or http.host). Both serverAddress and templatedPath must still match.
+        rule = {"serverAddress": "head-sampling-http-server", "templatedPath": "/http-match/exact/target"}
+        attributes = {"http.url": "http://head-sampling-http-server:8080/http-match/exact/target"}
         assert sampler._match_http_client_sample_rule(rule, attributes) is True
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
When running head sampling tests, two bugs surfaced:
1. urllib is not emitting a host name attribute, so we need to extract it
2. the server spans in the odigos sampler are not matching per segment, but uses .startwith()

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Various headsampling compatibility fixes
```
