### PR TITLE
CORE-1207: add trace flag support which is not merged yet in upstream

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-python-configurator"
-version = "1.0.88"
+version = "1.0.89"
 description = "Odigos Configurator for Python OpenTelemetry Auto-Instrumentation"
 requires-python = ">=3.9"
 authors = [
     { name = "Tamir David", email = "tamir@odigos.io" },
 ]
 dependencies = [
-    "odigos-opentelemetry-python == 1.0.88",
+    "odigos-opentelemetry-python == 1.0.89",
 ]
 
 [tool.uv.sources]

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -1,5 +1,11 @@
 from typing import Union
-from .lib_handling import reorder_python_path, reload_distro_modules, handle_django_instrumentation, handle_eventlet_instrumentation
+from .lib_handling import (
+    reorder_python_path,
+    reload_distro_modules,
+    handle_django_instrumentation,
+    handle_eventlet_instrumentation,
+    patch_otlp_span_flags,
+)
 
 handle_eventlet_instrumentation()
 
@@ -37,6 +43,11 @@ from opentelemetry.trace import set_tracer_provider, get_tracer_provider
 # Do this after the OpenTelemetry SDK imports above (load our SDK from the agent path
 # before reshuffling) and before opamp below (it imports protobuf—the app should own that).
 reorder_python_path()
+
+# Backport OTLP Span.flags trace-flags encoding 
+# (upstream PR #4761: https://github.com/open-telemetry/opentelemetry-python/pull/4761) 
+# onto the canonical exporter module now that sys.path prefers the agent's copy.
+patch_otlp_span_flags()
 
 from .version import VERSION
 from .exit_hook import ExitHooks

--- a/initializer/components.py
+++ b/initializer/components.py
@@ -44,8 +44,8 @@ from opentelemetry.trace import set_tracer_provider, get_tracer_provider
 # before reshuffling) and before opamp below (it imports protobuf—the app should own that).
 reorder_python_path()
 
-# Backport OTLP Span.flags trace-flags encoding 
-# (upstream PR #4761: https://github.com/open-telemetry/opentelemetry-python/pull/4761) 
+# Backport OTLP Span.flags trace-flags encoding
+# (upstream PR #4761: https://github.com/open-telemetry/opentelemetry-python/pull/4761)
 # onto the canonical exporter module now that sys.path prefers the agent's copy.
 patch_otlp_span_flags()
 

--- a/initializer/lib_handling.py
+++ b/initializer/lib_handling.py
@@ -88,19 +88,15 @@ def patch_otlp_span_flags() -> None:
     except ImportError:
         return
 
-    if hasattr(trace_encoder, "_odigos_trace_flags_patched"):
-        return
-
     original_encode_span = trace_encoder._encode_span
     original_encode_links = trace_encoder._encode_links
 
     # W3C TraceFlags is a single byte (values 0-255), and the encoder's existing
-    # flags only ever set the higher has-remote / is-remote bits. The two ranges
-    # never overlap, so adding the trace flags is equivalent to OR-ing them in.
+    # flags only ever set the higher has-remote / is-remote bits.
     def encode_span(sdk_span: ReadableSpan) -> PB2Span:
         encoded_span = original_encode_span(sdk_span)
         # THE FIX: fold the W3C trace flags into Span.flags (PR #4761).
-        encoded_span.flags += int(sdk_span.get_span_context().trace_flags)
+        encoded_span.flags |= int(sdk_span.get_span_context().trace_flags)
         return encoded_span
 
     def encode_links(links: Sequence[Link]) -> Optional[Sequence[PB2Span.Link]]:
@@ -109,7 +105,7 @@ def patch_otlp_span_flags() -> None:
             # Propagate the trace flags to links as well
             for link, encoded_link in zip(links, encoded_links):
                 # THE FIX: fold the W3C trace flags into Link.flags (PR #4761).
-                encoded_link.flags += int(link.context.trace_flags)
+                encoded_link.flags |= int(link.context.trace_flags)
         return encoded_links
 
     setattr(trace_encoder, "_encode_span", encode_span)

--- a/initializer/lib_handling.py
+++ b/initializer/lib_handling.py
@@ -1,6 +1,14 @@
+from __future__ import annotations
+
 import sys
 import importlib
 import os
+from typing import TYPE_CHECKING, Optional, Sequence
+
+if TYPE_CHECKING:
+    from opentelemetry.proto.trace.v1.trace_pb2 import Span as PB2Span
+    from opentelemetry.sdk.trace import ReadableSpan
+    from opentelemetry.trace import Link
 
 
 def reorder_python_path():
@@ -69,6 +77,44 @@ def handle_django_instrumentation():
             importlib.import_module(django_settings_module)
         except Exception:
             os.environ.setdefault("OTEL_PYTHON_DJANGO_INSTRUMENT", 'False')
+
+
+def patch_otlp_span_flags() -> None:
+    # Backport of https://github.com/open-telemetry/opentelemetry-python/pull/4761:
+    # include W3C TraceFlags (lower 8 bits, e.g. the sampled bit) in the OTLP Span.flags / Link.flags alongside the existing is-remote bits (8-9).
+    # We wrap the encode helpers instead of replacing _span_flags because the PR also changed that function's signature and both of its call sites.
+    try:
+        from opentelemetry.exporter.otlp.proto.common._internal import trace_encoder
+    except ImportError:
+        return
+
+    if hasattr(trace_encoder, "_odigos_trace_flags_patched"):
+        return
+
+    original_encode_span = trace_encoder._encode_span
+    original_encode_links = trace_encoder._encode_links
+
+    # W3C TraceFlags is a single byte (values 0-255), and the encoder's existing
+    # flags only ever set the higher has-remote / is-remote bits. The two ranges
+    # never overlap, so adding the trace flags is equivalent to OR-ing them in.
+    def encode_span(sdk_span: ReadableSpan) -> PB2Span:
+        encoded_span = original_encode_span(sdk_span)
+        # THE FIX: fold the W3C trace flags into Span.flags (PR #4761).
+        encoded_span.flags += int(sdk_span.get_span_context().trace_flags)
+        return encoded_span
+
+    def encode_links(links: Sequence[Link]) -> Optional[Sequence[PB2Span.Link]]:
+        encoded_links = original_encode_links(links)
+        if encoded_links:
+            # Propagate the trace flags to links as well
+            for link, encoded_link in zip(links, encoded_links):
+                # THE FIX: fold the W3C trace flags into Link.flags (PR #4761).
+                encoded_link.flags += int(link.context.trace_flags)
+        return encoded_links
+
+    setattr(trace_encoder, "_encode_span", encode_span)
+    setattr(trace_encoder, "_encode_links", encode_links)
+    setattr(trace_encoder, "_odigos_trace_flags_patched", True)
 
 
 def handle_eventlet_instrumentation():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "odigos-opentelemetry-python"
-version = "1.0.88"
+version = "1.0.89"
 description = "Odigos Initializer for Python OpenTelemetry Components"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ provides-extras = ["instruments"]
 
 [[package]]
 name = "odigos-opentelemetry-python"
-version = "1.0.88"
+version = "1.0.89"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },
@@ -1482,7 +1482,7 @@ dev = [
 
 [[package]]
 name = "odigos-python-configurator"
-version = "1.0.88"
+version = "1.0.89"
 source = { editable = "agent" }
 dependencies = [
     { name = "odigos-opentelemetry-python" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
This was introduced in this PR upstream:
`https://github.com/open-telemetry/opentelemetry-python/pull/4761` But wasn't merged yet.

This causes some problems for customers who want to use span metrics: The bundled opentelemetry-exporter-otlp-proto-common (1.40.0) only encodes the is-remote bits (8-9) into Span.flags, omitting the lower W3C TraceFlags byte including the sampled bit.
When span metrics mode: all-spans is enabled, we sample the span and signal that the span was sampled on the unencoded bits (0-7), and so the the node-collector's odigos_trace_filter sees the span as unsampled and drops them.

This fix monkey patches the 0-7 bits into the trace flags which indicate that we've sampled, and doesn't drop the spans.


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fixes upstream bug where span metric sampled spans were dropped, and not passed through to node collector
```
