### PR TITLE
CORE-1216: bump starlette and other libs in integration tests requirements to get rid of CVEs

### DIFF
--- a/tests/integration/apps/pythongunicorn/requirements.txt
+++ b/tests/integration/apps/pythongunicorn/requirements.txt
@@ -1,5 +1,5 @@
 # Core application dependencies
-gunicorn==22.0.0
-uvicorn==0.20.0
-importlib_metadata==1.7.0
-starlette==0.13.8
+gunicorn==26.0.0
+uvicorn==0.49.0
+importlib_metadata==9.0.0
+starlette==1.3.1

--- a/tests/integration/apps/sqlalchemy/requirements.txt
+++ b/tests/integration/apps/sqlalchemy/requirements.txt
@@ -1,3 +1,3 @@
-SQLAlchemy==2.0.23
-starlette==0.13.8
-uvicorn==0.20.0
+SQLAlchemy==2.0.51
+starlette==1.3.1
+uvicorn==0.49.0


### PR DESCRIPTION
We have some `requirements.txt` files in integration tests that dependebot (dependa? depndee? depdep? bot) insists that are CVEs.
They are not packed in our agent anyway but it was annoying nontheless

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
