### PR TITLE
CORE-1211: fix urllib3 high vuln in python

### DIFF
--- a/initializer/__init__.py
+++ b/initializer/__init__.py
@@ -14,9 +14,5 @@ def setup_logging():
     odigos_logger.propagate = False  # Prevent logs from reaching the root logger
     odigos_logger.disabled = True  # Comment to enable the logger
 
-    # Suppress third-party loggers used by odigos-opentelemetry-python (before they are used)
-    logging.getLogger('urllib3_odigos').setLevel(logging.CRITICAL)
-    logging.getLogger('requests_odigos').setLevel(logging.CRITICAL)
-
 
 setup_logging()

--- a/initializer/lib_handling.py
+++ b/initializer/lib_handling.py
@@ -40,13 +40,7 @@ def reload_distro_modules() -> None:
         'typing_extensions',
     ]
 
-    excluded_modules = ['urllib3_odigos', 'requests_odigos']
-
     for module in list(sys.modules):
-        # Check if the module starts with any of the needed prefixes, but not with any of the excluded prefixes.
-        if any(module.startswith(prefix) for prefix in excluded_modules):
-            continue
-
         if any(module.startswith(prefix) for prefix in needed_module_prefixes):
             module_file = getattr(sys.modules[module], '__file__', None)  # Safely get __file__
             if module_file and ('/etc/odigos-vmagent/' in module_file or '/var/odigos/' in module_file):

--- a/opamp/http_client.py
+++ b/opamp/http_client.py
@@ -5,7 +5,7 @@ import json
 import time
 import base64
 import threading
-import requests_odigos
+import http.client
 import logging
 
 from uuid_extensions import uuid7
@@ -251,8 +251,8 @@ class OpAMPHTTPClient:
                                     # Catch exception and don't update the config
                                     # The default config is preloaded when the EBPFSpanProcessor is initialized
                                     pass
-
-                except requests_odigos.RequestException:
+                # OSError contain all socket or network failures, and HTTPException is for HTTP protocol errors
+                except (OSError, http.client.HTTPException):
                     pass
                 self.condition.wait(30)
 
@@ -334,7 +334,7 @@ class OpAMPHTTPClient:
         try:
             agent_to_server = opamp_pb2.AgentToServer(remote_config_status=self.remote_config_status)
             return self.send_agent_to_server_message(agent_to_server)
-        except requests_odigos.RequestException:
+        except (OSError, http.client.HTTPException):
             pass
 
     def get_agent_description(self) -> opamp_pb2.AgentDescription:  # type: ignore

--- a/opamp/transport.py
+++ b/opamp/transport.py
@@ -2,19 +2,31 @@ import os
 import socket
 import http.client
 
-import requests_odigos
+_OPAMP_PATH = "/v1/opamp"
+
+
+def _post(conn: http.client.HTTPConnection, body: bytes, headers: dict) -> bytes:
+    try:
+        conn.request("POST", _OPAMP_PATH, body=body, headers=headers)
+        response = conn.getresponse()
+        status = response.status
+        data = response.read()
+        if status >= 400:
+            raise http.client.HTTPException(f"opamp POST returned status {status}")
+        return data
+    finally:
+        conn.close()
 
 
 class TCPTransport:
     """HTTP/1.1 over TCP. Talks to ODIGOS_OPAMP_SERVER_HOST."""
 
     def __init__(self, host: str):
-        self._url = f"http://{host}/v1/opamp"
+        self._host = host
 
     def post(self, body: bytes, headers: dict, timeout: float) -> bytes:
-        response = requests_odigos.post(self._url, data=body, headers=headers, timeout=timeout)
-        response.raise_for_status()
-        return response.content
+        conn = http.client.HTTPConnection(self._host, timeout=timeout)
+        return _post(conn, body, headers)
 
 
 class UnixTransport:
@@ -25,14 +37,7 @@ class UnixTransport:
 
     def post(self, body: bytes, headers: dict, timeout: float) -> bytes:
         conn = _UnixHTTPConnection(self._socket_path, timeout=timeout)
-        try:
-            conn.request("POST", "/v1/opamp", body=body, headers=headers)
-            response = conn.getresponse()
-            if response.status >= 400:
-                raise RuntimeError(f"opamp unix POST returned status {response.status}")
-            return response.read()
-        finally:
-            conn.close()
+        return _post(conn, body, headers)
 
 
 class _UnixHTTPConnection(http.client.HTTPConnection):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,10 @@ authors = [
 ]
 dependencies = [
     "uuid7 == 0.1.0",
-    "urllib3-odigos == 2.2.2",
-    "urllib3 === 2.2.3",
-    "odigos-requests == 2.32.3.dev0",
+    "urllib3 >= 2.6.3",  # security floor: urllib3 redirect/retry CVEs fixed in 2.5.0
     "zipp == 3.20.2",
     "idna == 3.10",
     "asgiref == 3.8.1",
-    "requests == 2.32.3",
     "certifi == 2025.1.31",
     "charset-normalizer == 3.4.1",
     "googleapis-common-protos == 1.66.0",

--- a/tests/opamp/test_http_client.py
+++ b/tests/opamp/test_http_client.py
@@ -1,6 +1,8 @@
+import http.client
+import socket
 import pytest
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from opamp.http_client import OpAMPHTTPClient
 from opamp import opamp_pb2
@@ -31,25 +33,24 @@ def test_client(mock_connection_event, mock_condition):
         return OpAMPHTTPClient(mock_connection_event, mock_condition)
 
 
+def patch_post(test_client, **kwargs):
+    """Patch the transport's post() with the given return_value/side_effect."""
+    return patch.object(test_client._transport, 'post', **kwargs)
+
+
 class TestSendAgentToServerMessage:
     def test_successful_response(self, test_client):
         expected_response = opamp_pb2.ServerToAgent()
         expected_response.instance_uid = b"test-uid"
 
-        mock_response = Mock()
-        mock_response.content = expected_response.SerializeToString()
-        mock_response.raise_for_status = Mock()
-
-        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
+        with patch_post(test_client, return_value=expected_response.SerializeToString()):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
             assert result.instance_uid == b"test-uid"
 
     def test_timeout_returns_empty_response(self, test_client):
-        import requests_odigos
-
-        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("Connection timed out")):
+        with patch_post(test_client, side_effect=socket.timeout("Connection timed out")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
@@ -57,45 +58,15 @@ class TestSendAgentToServerMessage:
             assert not result.ListFields()
 
     def test_connection_error_returns_empty_response(self, test_client):
-        import requests_odigos
-
-        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.ConnectionError("Connection refused")):
+        with patch_post(test_client, side_effect=ConnectionError("Connection refused")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
             assert isinstance(result, opamp_pb2.ServerToAgent)
             assert not result.ListFields()
 
-    def test_http_error_403_returns_empty_response(self, test_client):
-        import requests_odigos
-
-        mock_response = Mock()
-        mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("403 Forbidden")
-
-        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
-            message = opamp_pb2.AgentToServer()
-            result = test_client.send_agent_to_server_message(message)
-
-            assert isinstance(result, opamp_pb2.ServerToAgent)
-            assert not result.ListFields()
-
-    def test_http_error_500_returns_empty_response(self, test_client):
-        import requests_odigos
-
-        mock_response = Mock()
-        mock_response.raise_for_status.side_effect = requests_odigos.HTTPError("500 Internal Server Error")
-
-        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
-            message = opamp_pb2.AgentToServer()
-            result = test_client.send_agent_to_server_message(message)
-
-            assert isinstance(result, opamp_pb2.ServerToAgent)
-            assert not result.ListFields()
-
-    def test_request_exception_returns_empty_response(self, test_client):
-        import requests_odigos
-
-        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.RequestException("Some request error")):
+    def test_http_error_returns_empty_response(self, test_client):
+        with patch_post(test_client, side_effect=http.client.HTTPException("opamp POST returned status 500")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
@@ -103,7 +74,7 @@ class TestSendAgentToServerMessage:
             assert not result.ListFields()
 
     def test_unknown_exception_returns_empty_response(self, test_client):
-        with patch('opamp.transport.requests_odigos.post', side_effect=RuntimeError("Unexpected error")):
+        with patch_post(test_client, side_effect=RuntimeError("Unexpected error")):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
@@ -111,22 +82,16 @@ class TestSendAgentToServerMessage:
             assert not result.ListFields()
 
     def test_invalid_protobuf_response_returns_empty_response(self, test_client):
-        mock_response = Mock()
-        mock_response.content = b"invalid protobuf data"
-        mock_response.raise_for_status = Mock()
-
-        with patch('opamp.transport.requests_odigos.post', return_value=mock_response):
+        with patch_post(test_client, return_value=b"invalid protobuf data"):
             message = opamp_pb2.AgentToServer()
             result = test_client.send_agent_to_server_message(message)
 
             assert isinstance(result, opamp_pb2.ServerToAgent)
 
     def test_sequence_num_increments_on_each_call(self, test_client):
-        import requests_odigos
-
         initial_seq = test_client.next_sequence_num
 
-        with patch('opamp.transport.requests_odigos.post', side_effect=requests_odigos.Timeout("timeout")):
+        with patch_post(test_client, side_effect=socket.timeout("timeout")):
             test_client.send_agent_to_server_message(opamp_pb2.AgentToServer())
             assert test_client.next_sequence_num == initial_seq + 1
 
@@ -134,20 +99,18 @@ class TestSendAgentToServerMessage:
             assert test_client.next_sequence_num == initial_seq + 2
 
     def test_does_not_crash_app_on_any_exception(self, test_client):
-        import requests_odigos
-
         exceptions_to_test = [
-            requests_odigos.Timeout("timeout"),
-            requests_odigos.ConnectionError("connection error"),
-            requests_odigos.HTTPError("http error"),
-            requests_odigos.RequestException("request error"),
+            socket.timeout("timeout"),
+            ConnectionError("connection error"),
+            http.client.HTTPException("http error"),
+            OSError("os error"),
             RuntimeError("runtime error"),
             ValueError("value error"),
             Exception("generic exception"),
         ]
 
         for exc in exceptions_to_test:
-            with patch('opamp.transport.requests_odigos.post', side_effect=exc):
+            with patch_post(test_client, side_effect=exc):
                 message = opamp_pb2.AgentToServer()
                 result = test_client.send_agent_to_server_message(message)
                 assert isinstance(result, opamp_pb2.ServerToAgent), f"Failed for exception: {exc}"

--- a/tests/opamp/test_transport.py
+++ b/tests/opamp/test_transport.py
@@ -1,3 +1,4 @@
+import http.client
 import os
 from unittest.mock import Mock, patch
 
@@ -22,7 +23,7 @@ class TestFromEnv:
         with patch.dict(os.environ, {"ODIGOS_OPAMP_SERVER_HOST": "odigos-server:4318"}, clear=True):
             result = from_env()
         assert isinstance(result, TCPTransport)
-        assert result._url == "http://odigos-server:4318/v1/opamp"
+        assert result._host == "odigos-server:4318"
 
     def test_unix_takes_precedence_when_both_set(self):
         env = {
@@ -43,8 +44,8 @@ class TestFromEnv:
 # matching wire (unix socket OR tcp) and never accidentally use the other one.
 # We don't send real traffic - we mock both wires and check which one was hit.
 class TestPostRoutesThroughCorrectWire:
-    def test_unix_transport_post_uses_unix_socket_and_not_requests(self):
-        # Env says "use unix". post() should open a unix connection and never call requests [py library].
+    def test_unix_transport_post_uses_unix_socket(self):
+        # Env says "use unix". post() should open a unix connection and never a tcp one.
         mock_conn = Mock()
         mock_response = Mock(status=200)
         mock_response.read.return_value = b"unix-response"
@@ -56,50 +57,50 @@ class TestPostRoutesThroughCorrectWire:
 
         with (
             patch("opamp.transport._UnixHTTPConnection", return_value=mock_conn) as unix_conn_cls,
-            patch("opamp.transport.requests_odigos.post") as tcp_post,
+            patch("opamp.transport.http.client.HTTPConnection") as tcp_conn_cls,
         ):
             data = t.post(b"hello", {"Content-Type": "x"}, timeout=5)
 
         unix_conn_cls.assert_called_once_with("/sock", timeout=5)
         mock_conn.request.assert_called_once_with("POST", "/v1/opamp", body=b"hello", headers={"Content-Type": "x"})
-        tcp_post.assert_not_called()
+        tcp_conn_cls.assert_not_called()
         assert data == b"unix-response"
 
-    def test_tcp_transport_post_uses_requests_and_not_unix_socket(self):
-        # Env says "use tcp". post() should call requests_odigos and never open a unix connection.
-        mock_response = Mock(status_code=200, content=b"tcp-response")
-        mock_response.raise_for_status = Mock()
+    def test_tcp_transport_post_uses_tcp_connection_and_not_unix_socket(self):
+        # Env says "use tcp". post() should open a tcp connection and never a unix one.
+        mock_conn = Mock()
+        mock_response = Mock(status=200)
+        mock_response.read.return_value = b"tcp-response"
+        mock_conn.getresponse.return_value = mock_response
 
         with patch.dict(os.environ, {"ODIGOS_OPAMP_SERVER_HOST": "host:1234"}, clear=True):
             t = from_env()
         assert isinstance(t, TCPTransport)
 
         with (
-            patch("opamp.transport.requests_odigos.post", return_value=mock_response) as tcp_post,
+            patch("opamp.transport.http.client.HTTPConnection", return_value=mock_conn) as tcp_conn_cls,
             patch("opamp.transport._UnixHTTPConnection") as unix_conn_cls,
         ):
             data = t.post(b"hello", {"Content-Type": "x"}, timeout=5)
 
-        tcp_post.assert_called_once_with(
-            "http://host:1234/v1/opamp",
-            data=b"hello",
-            headers={"Content-Type": "x"},
-            timeout=5,
-        )
+        tcp_conn_cls.assert_called_once_with("host:1234", timeout=5)
+        mock_conn.request.assert_called_once_with("POST", "/v1/opamp", body=b"hello", headers={"Content-Type": "x"})
         unix_conn_cls.assert_not_called()
         assert data == b"tcp-response"
 
-    # If the unix server responds with an HTTP error (>=400), post() must raise
+    # If the server responds with an HTTP error (>=400), post() must raise
     # so the caller's try/except turns it into an empty ServerToAgent.
-    def test_unix_transport_raises_on_http_error_status(self):
+    def test_transport_raises_on_http_error_status(self):
         mock_conn = Mock()
-        mock_conn.getresponse.return_value = Mock(status=500)
+        mock_response = Mock(status=500)
+        mock_response.read.return_value = b""
+        mock_conn.getresponse.return_value = mock_response
 
         t = UnixTransport("/sock")
         with patch("opamp.transport._UnixHTTPConnection", return_value=mock_conn):
             try:
                 t.post(b"x", {}, timeout=1)
-            except RuntimeError as e:
+            except http.client.HTTPException as e:
                 assert "500" in str(e)
             else:
-                raise AssertionError("expected RuntimeError on 500 status")
+                raise AssertionError("expected HTTPException on 500 status")

--- a/uv.lock
+++ b/uv.lock
@@ -435,7 +435,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "certifi", marker = "python_full_version < '3.10'" },
-    { name = "urllib3", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/1f/2d1a1790df2b75e1e1eb90d8a3fe066a47ef95e34430657447e549cc274c/elastic_transport-9.1.0.tar.gz", hash = "sha256:1590e44a25b0fe208107d5e8d7dea15c070525f3ac9baafbe4cb659cd14f073d", size = 76483, upload-time = "2025-07-24T16:41:31.017Z" }
 wheels = [
@@ -452,7 +452,7 @@ resolution-markers = [
 dependencies = [
     { name = "certifi", marker = "python_full_version >= '3.10'" },
     { name = "sniffio", marker = "python_full_version >= '3.10'" },
-    { name = "urllib3", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/0a/a92140b666afdcb9862a16e4d80873b3c887c1b7e3f17e945fc3460edf1b/elastic_transport-9.2.1.tar.gz", hash = "sha256:97d9abd638ba8aa90faa4ca1bf1a18bde0fe2088fbc8757f2eb7b299f205773d", size = 77403, upload-time = "2025-12-23T11:54:12.849Z" }
 wheels = [
@@ -1318,7 +1318,6 @@ dependencies = [
     { name = "odigos-opentelemetry-instrumentation-elasticsearch" },
     { name = "odigos-opentelemetry-instrumentation-openai-v2" },
     { name = "odigos-opentelemetry-instrumentation-sqlalchemy" },
-    { name = "odigos-requests" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-aio-pika" },
@@ -1372,10 +1371,9 @@ dependencies = [
     { name = "opentelemetry-instrumentation-wsgi" },
     { name = "packaging" },
     { name = "protobuf" },
-    { name = "requests" },
     { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "urllib3-odigos" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uuid7" },
     { name = "wrapt" },
     { name = "zipp" },
@@ -1408,7 +1406,6 @@ requires-dist = [
     { name = "odigos-opentelemetry-instrumentation-elasticsearch", editable = "instrumentations/opentelemetry-instrumentation-elasticsearch" },
     { name = "odigos-opentelemetry-instrumentation-openai-v2", editable = "instrumentations/opentelemetry-instrumentation-openai-v2" },
     { name = "odigos-opentelemetry-instrumentation-sqlalchemy", editable = "instrumentations/opentelemetry-instrumentation-sqlalchemy" },
-    { name = "odigos-requests", specifier = "==2.32.3.dev0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.40.0" },
     { name = "opentelemetry-instrumentation", specifier = "==0.61b0" },
     { name = "opentelemetry-instrumentation-aio-pika", specifier = "==0.61b0" },
@@ -1463,10 +1460,8 @@ requires-dist = [
     { name = "packaging", specifier = "==24.2" },
     { name = "protobuf", specifier = "==5.29.6" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
-    { name = "requests", specifier = "==2.32.3" },
     { name = "typing-extensions", specifier = "==4.14.0" },
-    { name = "urllib3", specifier = "===2.2.3" },
-    { name = "urllib3-odigos", specifier = "==2.2.2" },
+    { name = "urllib3", specifier = ">=2.5.0" },
     { name = "uuid7", specifier = "==0.1.0" },
     { name = "wrapt", specifier = "==1.17.3" },
     { name = "zipp", specifier = "==3.20.2" },
@@ -1490,21 +1485,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "odigos-opentelemetry-python", editable = "." }]
-
-[[package]]
-name = "odigos-requests"
-version = "2.32.3.dev0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3-odigos" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/4e/8401a0770dccf211749ce4ef7037815c6a6ad7afeb1ad64dae66b586ee9b/odigos_requests-2.32.3.dev0.tar.gz", hash = "sha256:f70f6fd56049006b54b77202da8d92b578837f6ae66f870855dc7ea40002cf45", size = 129847, upload-time = "2024-08-28T14:22:23.658Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/0c/fd5defe89a62707acf0ae135524da63d977da11ecc8e5eb7d887ae8f9dba/odigos_requests-2.32.3.dev0-py3-none-any.whl", hash = "sha256:eeef9c7841ac0df433058cfa4e1e6843f3ca88c2d3359f7fabc8ce9c0b43e180", size = 65597, upload-time = "2024-08-28T14:22:21.776Z" },
-]
 
 [[package]]
 name = "openai"
@@ -2908,7 +2888,8 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
@@ -3139,20 +3120,26 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]
-name = "urllib3-odigos"
-version = "2.2.2"
+name = "urllib3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/9a/bb43b37e82fc5fe5836161b28c3e89837e3bd237b17125cfb9c8f0dbab71/urllib3_odigos-2.2.2.tar.gz", hash = "sha256:25d74ef3126a11139ff6d3c0503b875b40fd66fdb6d0d198ee8e77b5d3bed146", size = 292434, upload-time = "2024-08-28T13:11:02.597Z" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/c2/d5fb15e5e52142ae7498192e70a72610edd43ef60a6a311518398a65a031/urllib3_odigos-2.2.2-py3-none-any.whl", hash = "sha256:0be2955f1a1f078237c0b56f69c982efc8818a1ea054f20637ca331cc27d9d18", size = 122054, upload-time = "2024-08-28T13:11:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1461,7 +1461,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==5.29.6" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "typing-extensions", specifier = "==4.14.0" },
-    { name = "urllib3", specifier = ">=2.5.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uuid7", specifier = "==0.1.0" },
     { name = "wrapt", specifier = "==1.17.3" },
     { name = "zipp", specifier = "==3.20.2" },


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Remove urllib3 and requests odigos fork which brought vulnerabilites.
Use stdlib's http client for opamp, we don't need to use and pin requests for it.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix urllib3 and requests vulnerabilities
```
